### PR TITLE
Kill primary raf loop when presenting in VR

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1053,14 +1053,13 @@ function WebGLRenderer( parameters ) {
 	var onAnimationFrameCallback = null;
 
 	function onAnimationFrame( time ) {
-
-		if ( vr.isPresenting() ) return;
 		if ( onAnimationFrameCallback ) onAnimationFrameCallback( time );
 
 	}
 
 	var animation = new WebGLAnimation();
 	animation.setAnimationLoop( onAnimationFrame );
+	this.animation = animation;
 
 	if ( typeof window !== 'undefined' ) animation.setContext( window );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1053,6 +1053,7 @@ function WebGLRenderer( parameters ) {
 	var onAnimationFrameCallback = null;
 
 	function onAnimationFrame( time ) {
+
 		if ( onAnimationFrameCallback ) onAnimationFrameCallback( time );
 
 	}

--- a/src/renderers/webvr/WebVRManager.js
+++ b/src/renderers/webvr/WebVRManager.js
@@ -75,6 +75,7 @@ function WebVRManager( renderer ) {
 
 			renderer.setDrawingBufferSize( renderWidth * 2, renderHeight, 1 );
 
+			renderer.animation.stop();
 			animation.start();
 
 		} else {
@@ -86,6 +87,7 @@ function WebVRManager( renderer ) {
 			}
 
 			animation.stop();
+			renderer.animation.start();
 
 		}
 

--- a/src/renderers/webvr/WebXRManager.js
+++ b/src/renderers/webvr/WebXRManager.js
@@ -95,6 +95,7 @@ function WebXRManager( renderer ) {
 
 		renderer.setFramebuffer( null );
 		animation.stop();
+		renderer.animation.start();
 
 	}
 
@@ -130,6 +131,7 @@ function WebXRManager( renderer ) {
 
 				animation.setContext( session );
 				animation.start();
+				renderer.animation.stop();
 
 			} );
 


### PR DESCRIPTION
The primary raf loop in the renderer continues to run when presenting in VR. It skips doing any work but in profiling I noticed it adding unnecessary contention to the browser event queue and I see no advantage to have it continue running, so this PR simply stops it whenever the VR raf loop is going and resumes it again when the VR raf loops stops. This requires exposing the `WebGLAnimation` on the renderer, but this seems in line with most of the other things being exposed (like `properties`, `state`, etc)

raf contention:
![image](https://user-images.githubusercontent.com/130735/53998131-825eeb00-40f3-11e9-874a-bb4342085c4c.png)
