### PR TITLE
Prefer ImageBitmapLoader and dispose of textures after GPU upload

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -1669,6 +1669,8 @@ THREE.GLTFLoader = ( function () {
 
 			onLoad( result );
 
+			parser.cache.removeAll();
+
 		} ).catch( onError );
 
 	};

--- a/src/geometries/PlaneGeometry.js
+++ b/src/geometries/PlaneGeometry.js
@@ -33,7 +33,7 @@ PlaneGeometry.prototype.constructor = PlaneGeometry;
 
 // PlaneBufferGeometry
 
-function PlaneBufferGeometry( width, height, widthSegments, heightSegments, flipY = true) {
+function PlaneBufferGeometry( width, height, widthSegments, heightSegments, flipY = true ) {
 
 	BufferGeometry.call( this );
 

--- a/src/geometries/PlaneGeometry.js
+++ b/src/geometries/PlaneGeometry.js
@@ -9,7 +9,7 @@ import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 
 // PlaneGeometry
 
-function PlaneGeometry( width, height, widthSegments, heightSegments ) {
+function PlaneGeometry( width, height, widthSegments, heightSegments, flipY ) {
 
 	Geometry.call( this );
 
@@ -19,7 +19,8 @@ function PlaneGeometry( width, height, widthSegments, heightSegments ) {
 		width: width,
 		height: height,
 		widthSegments: widthSegments,
-		heightSegments: heightSegments
+		heightSegments: heightSegments,
+		flipY
 	};
 
 	this.fromBufferGeometry( new PlaneBufferGeometry( width, height, widthSegments, heightSegments ) );
@@ -32,7 +33,7 @@ PlaneGeometry.prototype.constructor = PlaneGeometry;
 
 // PlaneBufferGeometry
 
-function PlaneBufferGeometry( width, height, widthSegments, heightSegments ) {
+function PlaneBufferGeometry( width, height, widthSegments, heightSegments, flipY = true) {
 
 	BufferGeometry.call( this );
 
@@ -42,7 +43,8 @@ function PlaneBufferGeometry( width, height, widthSegments, heightSegments ) {
 		width: width,
 		height: height,
 		widthSegments: widthSegments,
-		heightSegments: heightSegments
+		heightSegments: heightSegments,
+		flipY: flipY
 	};
 
 	width = width || 1;
@@ -84,7 +86,11 @@ function PlaneBufferGeometry( width, height, widthSegments, heightSegments ) {
 			normals.push( 0, 0, 1 );
 
 			uvs.push( ix / gridX );
-			uvs.push( 1 - ( iy / gridY ) );
+			uvs.push(
+				flipY ?
+					1 - ( iy / gridY ) :
+					iy / gridY
+			);
 
 		}
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -42,6 +42,9 @@ Object.assign( TextureLoader.prototype, {
 		const cacheKey = this.manager.resolveURL( url );
 		loader.load( url, function ( image ) {
 
+			// Image was just added to cache before this function gets called, disable caching by immediatly removing it
+			Cache.remove( cacheKey );
+
 			texture.image = image;
 
 			// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
@@ -53,7 +56,6 @@ Object.assign( TextureLoader.prototype, {
 			texture.onUpdate = function () {
 
 				console.info( "Removing texture", texture.id, url );
-				Cache.remove( cacheKey );
 				texture.image.close && texture.image.close();
 				delete texture.image;
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -4,6 +4,7 @@
 
 import { RGBAFormat, RGBFormat } from '../constants.js';
 import { ImageLoader } from './ImageLoader.js';
+import { ImageBitmapLoader } from './ImageBitmapLoader.js';
 import { Texture } from '../textures/Texture.js';
 import { DefaultLoadingManager } from './LoadingManager.js';
 
@@ -22,7 +23,18 @@ Object.assign( TextureLoader.prototype, {
 
 		var texture = new Texture();
 
-		var loader = new ImageLoader( this.manager );
+		var loader;
+		if ( window.createImageBitmap !== undefined ) {
+
+			loader = new ImageBitmapLoader( this.manager );
+			texture.flipY = false;
+
+		} else {
+
+			loader = new ImageLoader( this.manager );
+
+		}
+
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -55,7 +55,6 @@ Object.assign( TextureLoader.prototype, {
 
 			texture.onUpdate = function () {
 
-				console.info( "Removing texture", texture.id, url );
 				texture.image.close && texture.image.close();
 				delete texture.image;
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -8,6 +8,7 @@ import { ImageBitmapLoader } from './ImageBitmapLoader.js';
 import { Texture } from '../textures/Texture.js';
 import { DefaultLoadingManager } from './LoadingManager.js';
 
+import { Cache } from './Cache.js';
 
 function TextureLoader( manager ) {
 
@@ -38,6 +39,7 @@ Object.assign( TextureLoader.prototype, {
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
 
+		const cacheKey = this.manager.resolveURL( url );
 		loader.load( url, function ( image ) {
 
 			texture.image = image;
@@ -47,6 +49,14 @@ Object.assign( TextureLoader.prototype, {
 
 			texture.format = isJPEG ? RGBFormat : RGBAFormat;
 			texture.needsUpdate = true;
+
+			texture.onUpdate = function () {
+
+				Cache.remove( cacheKey );
+				texture.image.close && texture.image.close();
+				delete texture.image;
+
+			};
 
 			if ( onLoad !== undefined ) {
 

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -52,6 +52,7 @@ Object.assign( TextureLoader.prototype, {
 
 			texture.onUpdate = function () {
 
+				console.info( "Removing texture", texture.id, url );
 				Cache.remove( cacheKey );
 				texture.image.close && texture.image.close();
 				delete texture.image;

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -736,6 +736,16 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			}
 
+			if ( window.ImageBitmap && texture.image instanceof ImageBitmap ) {
+
+				console.info( "upload texture", "ImageBitmap", texture.id );
+
+			} else if ( texture.image instanceof HTMLImageElement ) {
+
+				console.info( "upload texture", "HTMLImageElement", texture.id, texture.image.src );
+
+			}
+
 		}
 
 		if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -736,15 +736,15 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			}
 
-			if ( window.ImageBitmap && texture.image instanceof ImageBitmap ) {
+			// if ( window.ImageBitmap && texture.image instanceof ImageBitmap ) {
 
-				console.info( "upload texture", "ImageBitmap", texture.id );
+			// 	console.info( "upload texture", "ImageBitmap", texture.id );
 
-			} else if ( texture.image instanceof HTMLImageElement ) {
+			// } else if ( texture.image instanceof HTMLImageElement ) {
 
-				console.info( "upload texture", "HTMLImageElement", texture.id, texture.image.src );
+			// 	console.info( "upload texture", "HTMLImageElement", texture.id, texture.image.src );
 
-			}
+			// }
 
 		}
 


### PR DESCRIPTION
This is built on top for ThreeJS 103 changes. It does 2 independent things that both touch similar code and seem easier to test together:

- TextureLoader will use ImageBitmapLoader by default if `createImageBitmap` is available. Since Firefox does not support `createImageBitmap` options, we also turn off flipY on the textures we create. This is already the default in GLTFLoader but an option also needed to be exposed for the uvs generated in PlaneGeometry and PlaneBufferGeometry since Hubs uses those directly. 
- The `image` for a texture will be disposed of after upload to the GPU. This probably warrants a configurable option on the loader eventually, but nothing in Hubs currently cares about the image after the fact. This will likely change if we move our fonts or our 9patch images to actually using a TextureLoader instead of an a-asset-item, since both of these look at the texture's image to get dimensions.

There are some discussions in flight in THREE mainline about better ways to configure loaders, so its likely we might change how we are doing this if/when those things land, but this seems like a pretty maintainable patch in the meantime.