### PR TITLE
Avoid unnecessary calls to activeTexture

### DIFF
--- a/src/renderers/webgl/WebGLState.d.ts
+++ b/src/renderers/webgl/WebGLState.d.ts
@@ -83,6 +83,7 @@ export class WebGLState {
   getScissorTest(): boolean;
   activeTexture(webglSlot: any): void;
   bindTexture(webglType: any, webglTexture: any): void;
+	activeTextureThenBindTexture(webglSlot: any, webglType: any, webglTexture: any): void;
   // Same interface as https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compressedTexImage2D
   compressedTexImage2D(): void;
   // Same interface as https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -829,6 +829,37 @@ function WebGLState( gl, extensions, utils, capabilities ) {
 
 	}
 
+	function activeTextureThenBindTexture( webglSlot, webglType, webglTexture ) {
+
+		if ( webglSlot === undefined ) webglSlot = gl.TEXTURE0 + maxTextures - 1;
+
+		var boundTexture = currentBoundTextures[ webglSlot ];
+
+		if ( boundTexture === undefined ) {
+
+			boundTexture = { type: undefined, texture: undefined };
+			currentBoundTextures[ webglSlot ] = boundTexture;
+
+		}
+
+		if ( boundTexture.type !== webglType || boundTexture.texture !== webglTexture ) {
+
+			if ( currentTextureSlot !== webglSlot ) {
+
+				gl.activeTexture( webglSlot );
+				currentTextureSlot = webglSlot;
+
+			}
+
+			gl.bindTexture( webglType, webglTexture || emptyTextures[ webglType ] );
+
+			boundTexture.type = webglType;
+			boundTexture.texture = webglTexture;
+
+		}
+
+	}
+
 	function compressedTexImage2D() {
 
 		try {
@@ -961,6 +992,7 @@ function WebGLState( gl, extensions, utils, capabilities ) {
 
 		activeTexture: activeTexture,
 		bindTexture: bindTexture,
+		activeTextureThenBindTexture: activeTextureThenBindTexture,
 		compressedTexImage2D: compressedTexImage2D,
 		texImage2D: texImage2D,
 		texImage3D: texImage3D,

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -318,8 +318,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( _gl.TEXTURE_2D, textureProperties.__webglTexture );
+		state.activeTextureThenBindTexture( _gl.TEXTURE0 + slot, _gl.TEXTURE_2D, textureProperties.__webglTexture );
 
 	}
 
@@ -334,8 +333,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( _gl.TEXTURE_2D_ARRAY, textureProperties.__webglTexture );
+		state.activeTextureThenBindTexture( _gl.TEXTURE0 + slot, _gl.TEXTURE_2D_ARRAY, textureProperties.__webglTexture );
 
 	}
 
@@ -350,8 +348,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( _gl.TEXTURE_3D, textureProperties.__webglTexture );
+		state.activeTextureThenBindTexture( _gl.TEXTURE0 + slot, _gl.TEXTURE_3D, textureProperties.__webglTexture );
 
 	}
 
@@ -365,8 +362,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				initTexture( textureProperties, texture );
 
-				state.activeTexture( _gl.TEXTURE0 + slot );
-				state.bindTexture( _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
+				state.activeTextureThenBindTexture( _gl.TEXTURE0 + slot, _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
 
 				_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, texture.flipY );
 
@@ -466,8 +462,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			} else {
 
-				state.activeTexture( _gl.TEXTURE0 + slot );
-				state.bindTexture( _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
+				state.activeTextureThenBindTexture( _gl.TEXTURE0 + slot, _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
 
 			}
 
@@ -477,8 +472,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	function setTextureCubeDynamic( texture, slot ) {
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( _gl.TEXTURE_CUBE_MAP, properties.get( texture ).__webglTexture );
+		state.activeTextureThenBindTexture( _gl.TEXTURE0 + slot, _gl.TEXTURE_CUBE_MAP, properties.get( texture ).__webglTexture );
 
 	}
 
@@ -571,8 +565,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		initTexture( textureProperties, texture );
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( textureType, textureProperties.__webglTexture );
+		state.activeTextureThenBindTexture( _gl.TEXTURE0 + slot, textureType, textureProperties.__webglTexture );
 
 		_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, texture.flipY );
 		_gl.pixelStorei( _gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, texture.premultiplyAlpha );


### PR DESCRIPTION
When there are multiple copies of the same object in a scene (and in some other cases), textures are already bound to the correct slots so we can avoid calling `activeTexture`.

Before:
```
uniform1f: WebGLUniformLocation - ID: 132, 18914.99999999982
uniform2fv: WebGLUniformLocation - ID: 133, [..(2)..]
activeTexture: TEXTURE0
activeTexture: TEXTURE1
activeTexture: TEXTURE2
activeTexture: TEXTURE3
uniformMatrix4fv: WebGLUniformLocation - ID: 134, false, [..(16)..]
uniformMatrix3fv: WebGLUniformLocation - ID: 135, false, [..(9)..]
uniformMatrix4fv: WebGLUniformLocation - ID: 136, false, [..(16)..]
drawElements: TRIANGLES, 1668, UNSIGNED_SHORT, 0MeshStandardMaterialMeshStandardMaterial
```
After:
```
uniform1f: WebGLUniformLocation - ID: 132, 18914.99999999982
uniform2fv: WebGLUniformLocation - ID: 133, [..(2)..]
uniformMatrix4fv: WebGLUniformLocation - ID: 134, false, [..(16)..]
uniformMatrix3fv: WebGLUniformLocation - ID: 135, false, [..(9)..]
uniformMatrix4fv: WebGLUniformLocation - ID: 136, false, [..(16)..]
drawElements: TRIANGLES, 1668, UNSIGNED_SHORT, 0MeshStandardMaterialMeshStandardMaterial
```


Before:
![image](https://user-images.githubusercontent.com/4072106/56097988-1f116700-5eb0-11e9-9bce-32777505f5fc.png)

After:
![image](https://user-images.githubusercontent.com/4072106/56098196-e7f08500-5eb2-11e9-8827-842a5e8719fc.png)

