### PR TITLE
Use insertionSort instead Array.prototype.sort to avoid allocations.

### DIFF
--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -132,8 +132,26 @@ function WebGLRenderList() {
 
 	function sort() {
 
-		if ( opaque.length > 1 ) opaque.sort( painterSortStable );
-		if ( transparent.length > 1 ) transparent.sort( reversePainterSortStable );
+		if ( opaque.length > 1 ) insertionSort( opaque, painterSortStable );
+		if ( transparent.length > 1 ) insertionSort( transparent, reversePainterSortStable );
+
+	}
+
+	function insertionSort( items, compareFunction ) {
+
+		for ( var i = 0; i < items.length; i ++ ) {
+
+			var value = items[ i ];
+			for ( var j = i - 1; j >= 0 && compareFunction( items[ j ], value ); j -- ) {
+
+				items[ j + 1 ] = items[ j ];
+
+			}
+			items[ j + 1 ] = value;
+
+		}
+
+		return items;
 
 	}
 


### PR DESCRIPTION
At least in Firefox, calling the native `Array.prototype.sort` method allocates memory. We want to avoid this allocation as long as the replacement for sort isn't too slow. On Oculus Go in a profile that lasted 15000ms in the atrium without spawning any ducks, it took <20 ms):
![image](https://user-images.githubusercontent.com/4072106/56167329-c49a0880-5f8c-11e9-8660-77adfa185848.png)

When there were 29 opaque objects and 13 transparent objects, in a profile that was 20000ms:
![image](https://user-images.githubusercontent.com/4072106/56167812-0ecfb980-5f8e-11e9-963b-19af9d4cb6d4.png)

In another 20000ms sample (with the same objects as before), the native `sort` seemed to be slightly faster, but not by much:
![image](https://user-images.githubusercontent.com/4072106/56169182-2c068700-5f92-11e9-864a-b71a9da22a9c.png)

In a 60 second sample (using the native sort):
![image](https://user-images.githubusercontent.com/4072106/56169332-9cada380-5f92-11e9-82f7-2fa80ee4926f.png)


I am not sure what is acceptable performance here. I suspect we could choose a faster sorting algorithm and get a small win, but the native array sort is probably fastest. The arrays we expect are not particularly long: I suspect they are mostly in the 10s and occasionally in the low hundreds.
