### PR TITLE
Use node uuids for animation paths and fix morph target caching

### DIFF
--- a/examples/js/exporters/GLTFExporter.js
+++ b/examples/js/exporters/GLTFExporter.js
@@ -117,6 +117,7 @@ THREE.GLTFExporter.prototype = {
 
 			meshes: new Map(),
 			attributes: new Map(),
+			attributesRelative: new Map(),
 			attributesNormalized: new Map(),
 			materials: new Map(),
 			textures: new Map(),
@@ -1250,9 +1251,9 @@ THREE.GLTFExporter.prototype = {
 
 						var baseAttribute = geometry.attributes[ attributeName ];
 
-						if ( cachedData.attributes.has( getUID( attribute ) ) ) {
+						if ( cachedData.attributesRelative.has( getUID( attribute ) ) ) {
 
-							target[ gltfAttributeName ] = cachedData.attributes.get( getUID( attribute ) );
+							target[ gltfAttributeName ] = cachedData.attributesRelative.get( getUID( attribute ) );
 							continue;
 
 						}
@@ -1272,7 +1273,7 @@ THREE.GLTFExporter.prototype = {
 						}
 
 						target[ gltfAttributeName ] = processAccessor( relativeAttribute, geometry );
-						cachedData.attributes.set( getUID( baseAttribute ), target[ gltfAttributeName ] );
+						cachedData.attributesRelative.set( getUID( baseAttribute ), target[ gltfAttributeName ] );
 
 					}
 

--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2810,8 +2810,6 @@ THREE.GLTFLoader = ( function () {
 
 				}
 
-				var targetName = node.name ? node.name : node.uuid;
-
 				var interpolation = sampler.interpolation !== undefined ? INTERPOLATION[ sampler.interpolation ] : THREE.InterpolateLinear;
 
 				var targetNames = [];
@@ -2823,7 +2821,7 @@ THREE.GLTFLoader = ( function () {
 
 						if ( object.isMesh === true && object.morphTargetInfluences ) {
 
-							targetNames.push( object.name ? object.name : object.uuid );
+							targetNames.push( object.uuid );
 
 						}
 
@@ -2831,7 +2829,7 @@ THREE.GLTFLoader = ( function () {
 
 				} else {
 
-					targetNames.push( targetName );
+					targetNames.push( node.uuid );
 
 				}
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -141,6 +141,7 @@ GLTFExporter.prototype = {
 
 			meshes: new Map(),
 			attributes: new Map(),
+			attributesRelative: new Map(),
 			attributesNormalized: new Map(),
 			materials: new Map(),
 			textures: new Map(),
@@ -1274,9 +1275,9 @@ GLTFExporter.prototype = {
 
 						var baseAttribute = geometry.attributes[ attributeName ];
 
-						if ( cachedData.attributes.has( getUID( attribute ) ) ) {
+						if ( cachedData.attributesRelative.has( getUID( attribute ) ) ) {
 
-							target[ gltfAttributeName ] = cachedData.attributes.get( getUID( attribute ) );
+							target[ gltfAttributeName ] = cachedData.attributesRelative.get( getUID( attribute ) );
 							continue;
 
 						}
@@ -1296,7 +1297,7 @@ GLTFExporter.prototype = {
 						}
 
 						target[ gltfAttributeName ] = processAccessor( relativeAttribute, geometry );
-						cachedData.attributes.set( getUID( baseAttribute ), target[ gltfAttributeName ] );
+						cachedData.attributesRelative.set( getUID( baseAttribute ), target[ gltfAttributeName ] );
 
 					}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2876,8 +2876,6 @@ var GLTFLoader = ( function () {
 
 				}
 
-				var targetName = node.name ? node.name : node.uuid;
-
 				var interpolation = sampler.interpolation !== undefined ? INTERPOLATION[ sampler.interpolation ] : InterpolateLinear;
 
 				var targetNames = [];
@@ -2889,7 +2887,7 @@ var GLTFLoader = ( function () {
 
 						if ( object.isMesh === true && object.morphTargetInfluences ) {
 
-							targetNames.push( object.name ? object.name : object.uuid );
+							targetNames.push( object.uuid );
 
 						}
 
@@ -2897,7 +2895,7 @@ var GLTFLoader = ( function () {
 
 				} else {
 
-					targetNames.push( targetName );
+					targetNames.push( node.uuid );
 
 				}
 


### PR DESCRIPTION
This PR is to be merged with https://github.com/mozilla/hubs/pull/1572 and https://github.com/mozilla/Spoke/pull/713
- Fixes loading animations in glTF models with duplicate node names
- Fixes exporting scenes with duplicate meshes with morph targets