### PR TITLE
Do not log failed shader source

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -58,9 +58,11 @@ function getShaderErrors( gl, shader, type ) {
 	// --enable-privileged-webgl-extension
 	// console.log( '**' + type + '**', gl.getExtension( 'WEBGL_debug_shaders' ).getTranslatedShaderSource( shader ) );
 
-	var source = gl.getShaderSource( shader );
+	// var source = gl.getShaderSource( shader );
 
-	return 'THREE.WebGLShader: gl.getShaderInfoLog() ' + type + '\n' + log + addLineNumbers( source );
+	// return 'THREE.WebGLShader: gl.getShaderInfoLog() ' + type + '\n' + log + addLineNumbers( source );
+
+	return 'THREE.WebGLShader: gl.getShaderInfoLog() ' + type + '\n' + log;
 
 }
 


### PR DESCRIPTION
If a shader fails to load, its source is dumped to the console. This could happen many times, if many objects try are using the failed shader. 
I suspect this is contributing to tabs crashing, but I have not verified this claim.