### PR TITLE
Fix transparency when using texture as emissive and base color map

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -2389,6 +2389,9 @@ THREE.GLTFLoader = ( function () {
 			if ( material.emissiveMap ) material.emissiveMap.encoding = THREE.sRGBEncoding;
 			if ( material.specularMap ) material.specularMap.encoding = THREE.sRGBEncoding;
 
+			// We cannot assume the texture pixel format is RGB if the texture is used for base color and emissive maps
+			if ( material.map && material.map === material.emissiveMap && ( material.transparent || material.alphaTest > 0.0 ) ) material.map.format = THREE.RGBAFormat;
+
 			assignExtrasToUserData( material, materialDef );
 
 			if ( materialDef.extensions ) addUnknownExtensionsToUserData( extensions, material, materialDef );

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2455,6 +2455,9 @@ var GLTFLoader = ( function () {
 			if ( material.emissiveMap ) material.emissiveMap.encoding = sRGBEncoding;
 			if ( material.specularMap ) material.specularMap.encoding = sRGBEncoding;
 
+			// We cannot assume the texture pixel format is RGB if the texture is used for base color and emissive maps
+			if ( material.map && material.map === material.emissiveMap && ( material.transparent || material.alphaTest > 0.0 ) ) material.map.format = RGBAFormat;
+
 			assignExtrasToUserData( material, materialDef );
 
 			if ( materialDef.extensions ) addUnknownExtensionsToUserData( extensions, material, materialDef );


### PR DESCRIPTION
Use RGBA pixel format for textures when they are used as both the emissive and base color map of a transparent material.