### PR TITLE
Add ImageBitmapLoader.prototype.isImageBitmapLoader = true

### DIFF
--- a/src/loaders/ImageBitmapLoader.d.ts
+++ b/src/loaders/ImageBitmapLoader.d.ts
@@ -7,6 +7,8 @@ export class ImageBitmapLoader extends Loader {
 
 	options: undefined | object;
 
+	isImageBitmapLoader: true;
+
 	setOptions( options: object ): ImageBitmapLoader;
 	load(
 		url: string,

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -30,6 +30,8 @@ ImageBitmapLoader.prototype = Object.assign( Object.create( Loader.prototype ), 
 
 	constructor: ImageBitmapLoader,
 
+	isImageBitmapLoader: true,
+
 	setOptions: function setOptions( options ) {
 
 		this.options = options;


### PR DESCRIPTION
From https://github.com/mozilla/hubs/issues/4117

This change is necessary to replace our glTF loader fork to the official one in Hubs, and it shouldn't hurt.