### PR TITLE
Add Object3D.applyMatrix4

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -130,6 +130,12 @@ Object3D.prototype = Object.assign( Object.create( EventDispatcher.prototype ), 
 
 	applyMatrix: function ( matrix ) {
 
+		return this.applyMatrix4( matrix );
+
+	},
+
+	applyMatrix4: function ( matrix ) {
+
 		if ( this.matrixAutoUpdate ) this.updateMatrix();
 
 		this.matrix.premultiply( matrix );


### PR DESCRIPTION
From https://github.com/mozilla/hubs/issues/4117

We need to apply this going forward change for replacing our glTF loader with the official one.

It seems `Object3D.applyMatrix()` has been renamed to `Object3D.applyMatrix4()` at some point. Our Three.js core fork (r111) keeps using `.applyMatrix()` while the latest glTF loader uses `.applyMatrix4()`. So I added `Object3D.applyMatrix4()` which just calls `Object3D.applyMatrix()`.