### PR TITLE
Refleciton probes

### DIFF
--- a/build/three.module.js
+++ b/build/three.module.js
@@ -26992,7 +26992,8 @@ function WebGLRenderer( parameters = {} ) {
 
 			if ( object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
 
-				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
+				envMapA = object.__webglStaticReflectionProbe.envMap;
+				p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
 				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -13494,7 +13494,13 @@ const ShaderLib = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
-			UniformsLib.envmap,
+			( () => {
+
+				// TODO HACK don't include envMap uniform, it is currently handling directly in WebGLRenderer for ReflectionProbes support
+				const { envMap, ...rest } = UniformsLib.envmap; // eslint-disable-line no-unused-vars
+				return rest;
+
+			} )(),
 			UniformsLib.aomap,
 			UniformsLib.lightmap,
 			UniformsLib.emissivemap,
@@ -24653,7 +24659,12 @@ function WebGLMaterials( properties ) {
 
 		if ( envMap ) {
 
-			uniforms.envMap.value = envMap;
+			// TODO HACK currently handling directly in WebGLRenderer only for MeshStandardMaterial for ReflectionProbes
+			if ( ! material.isMeshStandardMaterial ) {
+
+				uniforms.envMap.value = envMap;
+
+			}
 
 			uniforms.flipEnvMap.value = ( envMap.isCubeTexture && envMap.isRenderTargetTexture === false ) ? - 1 : 1;
 
@@ -26986,14 +26997,14 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		// Similar to note about skinned meshes above, this must be done before other texture uploads otherwise the texture units might overlap
-		let envMapA = null;
+		// This is not done in refreshMaterialUniforms because we want to be able to support the same material using different enviornment map (based on its location)
+		// Because of this, similar to the above note about skinned meshes, this must be done before refreshMaterialUniforms is called, and both texture uniforms must
+		// be set in all cases to prevent texture units from becoming out of sync when refreshMaterials is not set.
 		if ( materialProperties.envMap && material.isMeshStandardMaterial ) {
 
 			if ( object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
 
-				envMapA = object.__webglStaticReflectionProbe.envMap;
-				p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
+				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
 				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
 
@@ -27008,6 +27019,7 @@ function WebGLRenderer( parameters = {} ) {
 
 				_tmpObjectAABB.copy( geometry.boundingBox ).applyMatrix4( object.matrixWorld );
 
+				let envMapA = null;
 				let envMapB = null;
 				let maxVolumeA = 0;
 				let maxVolumeB = 0;
@@ -27059,8 +27071,9 @@ function WebGLRenderer( parameters = {} ) {
 
 			} else {
 
-				// p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
-				p_uniforms.setValue( _gl, 'envMap2', cubeuvmaps.get( scene.environment ), textures );
+				const defaultEnv = cubeuvmaps.get( scene.environment );
+				p_uniforms.setValue( _gl, 'envMap', defaultEnv, textures );
+				p_uniforms.setValue( _gl, 'envMap2', defaultEnv, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
 
 			}
@@ -27110,13 +27123,6 @@ function WebGLRenderer( parameters = {} ) {
 			}
 
 			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget );
-
-			// TODO HACK refreshMaterialUniforms overrides this, we should not be fighting it, but we don't want to force a full refreshMateerialUniforms on every object every frame to support reflection probes
-			if ( envMapA ) {
-
-				m_uniforms.envMap.value = envMapA;
-
-			}
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -27002,13 +27002,13 @@ function WebGLRenderer( parameters = {} ) {
 		// be set in all cases to prevent texture units from becoming out of sync when refreshMaterials is not set.
 		if ( materialProperties.envMap && material.isMeshStandardMaterial ) {
 
-			if ( object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
+			if ( ! material.envMap && object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
 
 				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
 				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
 
-			} else if ( object.reflectionProbeMode ) {
+			} else if ( ! material.envMap && object.reflectionProbeMode ) {
 
 				if ( ! geometry.boundingBox ) {
 
@@ -27071,9 +27071,8 @@ function WebGLRenderer( parameters = {} ) {
 
 			} else {
 
-				const defaultEnv = cubeuvmaps.get( scene.environment );
-				p_uniforms.setValue( _gl, 'envMap', defaultEnv, textures );
-				p_uniforms.setValue( _gl, 'envMap2', defaultEnv, textures );
+				p_uniforms.setValue( _gl, 'envMap', materialProperties.envMap, textures );
+				p_uniforms.setValue( _gl, 'envMap2', materialProperties.envMap, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
 
 			}

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -26981,45 +26981,58 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-        // Similar to note about skinned meshes above, this must be done before other texture uploads otherwise the texture units might overlap
+		// Similar to note about skinned meshes above, this must be done before other texture uploads otherwise the texture units might overlap
 		let envMapA = null;
-		if(materialProperties.envMap && material.isMeshStandardMaterial) {
-			if(object.reflectionProbeMode === "static" && object.__webglStaticReflectionProbe) {
+		if ( materialProperties.envMap && material.isMeshStandardMaterial ) {
+
+			if ( object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
+
 				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
 				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
-			} else if(object.reflectionProbeMode) {
-				if(!geometry.boundingBox) {
-					console.log("generated bounding box for ", object.name);
+
+			} else if ( object.reflectionProbeMode ) {
+
+				if ( ! geometry.boundingBox ) {
+
+					console.log( 'generated bounding box for ', object.name );
 					geometry.computeBoundingBox();
+
 				}
 
-				_tmpObjectAABB.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld);
+				_tmpObjectAABB.copy( geometry.boundingBox ).applyMatrix4( object.matrixWorld );
 
 				let envMapB = null;
 				let maxVolumeA = 0;
 				let maxVolumeB = 0;
 
-				// TODO maybe move probes to render state, collect at the same time we collect lights
 				const probes = lights.state.reflectionProbes;
-				for(let i = 0; i< probes.length; i++) {
-					if(probes[i].box.intersectsBox(_tmpObjectAABB)) {
-						const volume = _tmpOverlapBox.copy(_tmpObjectAABB).intersect(probes[i].box).volume();
-						if(volume > maxVolumeA) {
+				for ( let i = 0; i < probes.length; i ++ ) {
+
+					if ( probes[ i ].box.intersectsBox( _tmpObjectAABB ) ) {
+
+						const volume = _tmpOverlapBox.copy( _tmpObjectAABB ).intersect( probes[ i ].box ).volume();
+						if ( volume > maxVolumeA ) {
+
 							envMapB = envMapA;
 							maxVolumeB = maxVolumeA;
-							envMapA = probes[i].texture;
+							envMapA = probes[ i ].texture;
 							maxVolumeA = volume;
-						} else if(volume > maxVolumeB) {
-							envMapB = probes[i].texture;
+
+						} else if ( volume > maxVolumeB ) {
+
+							envMapB = probes[ i ].texture;
 							maxVolumeB = volume;
+
 						}
+
 					}
+
 				}
 
 				const blend = envMapB ?
-					maxVolumeB / (maxVolumeA + maxVolumeB) : 
-					1 - (maxVolumeA / _tmpObjectAABB.volume());
+					  maxVolumeB / ( maxVolumeA + maxVolumeB ) :
+					  1 - ( maxVolumeA / _tmpObjectAABB.volume() );
 
 				envMapA = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapA || environment );
 				envMapB = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapB || environment );
@@ -27028,19 +27041,24 @@ function WebGLRenderer( parameters = {} ) {
 				p_uniforms.setValue( _gl, 'envMap2', envMapB, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', blend );
 
-				if(object.reflectionProbeMode === "static") {
+				if(object.reflectionProbeMode === 'static') {
+
 					object.__webglStaticReflectionProbe = {
 						envMap: envMapA,
 						envMap2: envMapB,
 						envMapBlend: blend
 					};
+
 				}
+
 			} else {
+
 				// p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
 				p_uniforms.setValue( _gl, 'envMap2', cubeuvmaps.get(scene.environment), textures);
 				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
-                
+
 			}
+
 		}
 
 		if ( !! geometry && ( geometry.morphAttributes.position !== undefined || geometry.morphAttributes.normal !== undefined ) ) {
@@ -27087,10 +27105,12 @@ function WebGLRenderer( parameters = {} ) {
 
 			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget );
 
-            // TODO HACK refreshMaterialUniforms overrides this, we need to not be fighting it
-            if(envMapA) {
+			// TODO HACK refreshMaterialUniforms overrides this, we should not be fighting it, but we don't want to force a full refreshMateerialUniforms on every object every frame to support reflection probes
+			if ( envMapA ) {
+
 				m_uniforms.envMap.value = envMapA;
-            }
+
+			}
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -4138,7 +4138,9 @@ class Box3 {
 	}
 
 	volume() {
-		return ((this.max.x - this.min.x) * (this.max.y - this.min.y) * (this.max.z - this.min.z));
+
+		return ( ( this.max.x - this.min.x ) * ( this.max.y - this.min.y ) * ( this.max.z - this.min.z ) );
+
 	}
 
 	set( min, max ) {
@@ -6707,6 +6709,7 @@ class Object3D extends EventDispatcher {
 
 		this.castShadow = false;
 		this.receiveShadow = false;
+		this.reflectionProbeMode = false;
 
 		this.frustumCulled = true;
 		this.renderOrder = 0;
@@ -19876,7 +19879,7 @@ function WebGLLights( extensions, capabilities ) {
 
 			} else if ( light.isReflectionProbe ) {
 
-				state.reflectionProbes[numReflectionProbes++] = light;
+				state.reflectionProbes[ numReflectionProbes ++ ] = light;
 
 			} else if ( light.isDirectionalLight ) {
 
@@ -25408,8 +25411,8 @@ function WebGLRenderer( parameters = {} ) {
 
 	const _vector3 = new Vector3();
 
-	const _tmpObjectAABB = new THREE.Box3();
-	const _tmpOverlapBox = new THREE.Box3();
+	const _tmpObjectAABB = new Box3();
+	const _tmpOverlapBox = new Box3();
 
 	const _emptyScene = { background: null, fog: null, environment: null, overrideMaterial: null, isScene: true };
 
@@ -26488,8 +26491,10 @@ function WebGLRenderer( parameters = {} ) {
 
 		// TODO this triggers cubemap generation up front, should probably be done elsewhere
 		const reflectionProbes = currentRenderState.state.lights.state.reflectionProbes;
-		for(let i = 0; i<reflectionProbes.length; i++) {
-			cubeuvmaps.get(reflectionProbes[i].texture);
+		for ( let i = 0; i < reflectionProbes.length; i ++ ) {
+
+			cubeuvmaps.get( reflectionProbes[ i ].texture );
+
 		}
 
 		if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, scene, camera );
@@ -27041,7 +27046,7 @@ function WebGLRenderer( parameters = {} ) {
 				p_uniforms.setValue( _gl, 'envMap2', envMapB, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', blend );
 
-				if(object.reflectionProbeMode === 'static') {
+				if ( object.reflectionProbeMode === 'static' ) {
 
 					object.__webglStaticReflectionProbe = {
 						envMap: envMapA,
@@ -27054,7 +27059,7 @@ function WebGLRenderer( parameters = {} ) {
 			} else {
 
 				// p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
-				p_uniforms.setValue( _gl, 'envMap2', cubeuvmaps.get(scene.environment), textures);
+				p_uniforms.setValue( _gl, 'envMap2', cubeuvmaps.get( scene.environment ), textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
 
 			}
@@ -42270,7 +42275,7 @@ AmbientLightProbe.prototype.isAmbientLightProbe = true;
 
 class ReflectionProbe extends Light {
 
-	constructor( box = new Box3(), texture) {
+	constructor( box = new Box3(), texture ) {
 
 		super();
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -26982,6 +26982,7 @@ function WebGLRenderer( parameters = {} ) {
 		}
 
         // Similar to note about skinned meshes above, this must be done before other texture uploads otherwise the texture units might overlap
+		let envMapA = null;
 		if(materialProperties.envMap && material.isMeshStandardMaterial) {
 			if(object.reflectionProbeMode === "static" && object.__webglStaticReflectionProbe) {
 				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
@@ -26995,7 +26996,6 @@ function WebGLRenderer( parameters = {} ) {
 
 				_tmpObjectAABB.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld);
 
-				let envMapA = null;
 				let envMapB = null;
 				let maxVolumeA = 0;
 				let maxVolumeB = 0;
@@ -27086,6 +27086,11 @@ function WebGLRenderer( parameters = {} ) {
 			}
 
 			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget );
+
+            // TODO HACK refreshMaterialUniforms overrides this, we need to not be fighting it
+            if(envMapA) {
+				m_uniforms.envMap.value = envMapA;
+            }
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -4137,6 +4137,10 @@ class Box3 {
 
 	}
 
+	volume() {
+		return ((this.max.x - this.min.x) * (this.max.y - this.min.y) * (this.max.z - this.min.z));
+	}
+
 	set( min, max ) {
 
 		this.min.copy( min );
@@ -12855,7 +12859,7 @@ var encodings_pars_fragment = "\nvec4 LinearToLinear( in vec4 value ) {\n\tretur
 
 var envmap_fragment = "#ifdef USE_ENVMAP\n\t#ifdef ENV_WORLDPOS\n\t\tvec3 cameraToFrag;\n\t\tif ( isOrthographic ) {\n\t\t\tcameraToFrag = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );\n\t\t} else {\n\t\t\tcameraToFrag = normalize( vWorldPosition - cameraPosition );\n\t\t}\n\t\tvec3 worldNormal = inverseTransformDirection( normal, viewMatrix );\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvec3 reflectVec = reflect( cameraToFrag, worldNormal );\n\t\t#else\n\t\t\tvec3 reflectVec = refract( cameraToFrag, worldNormal, refractionRatio );\n\t\t#endif\n\t#else\n\t\tvec3 reflectVec = vReflect;\n\t#endif\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tvec4 envColor = textureCube( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ) );\n\t\tenvColor = envMapTexelToLinear( envColor );\n\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\tvec4 envColor = textureCubeUV( envMap, reflectVec, 0.0 );\n\t#else\n\t\tvec4 envColor = vec4( 0.0 );\n\t#endif\n\t#ifdef ENVMAP_BLENDING_MULTIPLY\n\t\toutgoingLight = mix( outgoingLight, outgoingLight * envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_MIX )\n\t\toutgoingLight = mix( outgoingLight, envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_ADD )\n\t\toutgoingLight += envColor.xyz * specularStrength * reflectivity;\n\t#endif\n#endif";
 
-var envmap_common_pars_fragment = "#ifdef USE_ENVMAP\n\tuniform float envMapIntensity;\n\tuniform float flipEnvMap;\n\tuniform int maxMipLevel;\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tuniform samplerCube envMap;\n\t#else\n\t\tuniform sampler2D envMap;\n\t#endif\n\t\n#endif";
+var envmap_common_pars_fragment = "#ifdef USE_ENVMAP\n\tuniform float envMapIntensity;\n\tuniform float flipEnvMap;\n\tuniform int maxMipLevel;\n\tuniform float envMapBlend;\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tuniform samplerCube envMap;\n\t#else\n\t\tuniform sampler2D envMap;\n\t\tuniform sampler2D envMap2;\n\t#endif\n\t\n#endif";
 
 var envmap_pars_fragment = "#ifdef USE_ENVMAP\n\tuniform float reflectivity;\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )\n\t\t#define ENV_WORLDPOS\n\t#endif\n\t#ifdef ENV_WORLDPOS\n\t\tvarying vec3 vWorldPosition;\n\t\tuniform float refractionRatio;\n\t#else\n\t\tvarying vec3 vReflect;\n\t#endif\n#endif";
 
@@ -12881,7 +12885,7 @@ var lights_lambert_vertex = "vec3 diffuse = vec3( 1.0 );\nGeometricContext geome
 
 var lights_pars_begin = "uniform bool receiveShadow;\nuniform vec3 ambientLightColor;\nuniform vec3 lightProbe[ 9 ];\nvec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {\n\tfloat x = normal.x, y = normal.y, z = normal.z;\n\tvec3 result = shCoefficients[ 0 ] * 0.886227;\n\tresult += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;\n\tresult += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;\n\tresult += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;\n\tresult += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;\n\tresult += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;\n\tresult += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );\n\tresult += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;\n\tresult += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );\n\treturn result;\n}\nvec3 getLightProbeIrradiance( const in vec3 lightProbe[ 9 ], const in vec3 normal ) {\n\tvec3 worldNormal = inverseTransformDirection( normal, viewMatrix );\n\tvec3 irradiance = shGetIrradianceAt( worldNormal, lightProbe );\n\treturn irradiance;\n}\nvec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {\n\tvec3 irradiance = ambientLightColor;\n\treturn irradiance;\n}\nfloat getDistanceAttenuation( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {\n\t#if defined ( PHYSICALLY_CORRECT_LIGHTS )\n\t\tfloat distanceFalloff = 1.0 / max( pow( lightDistance, decayExponent ), 0.01 );\n\t\tif ( cutoffDistance > 0.0 ) {\n\t\t\tdistanceFalloff *= pow2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) );\n\t\t}\n\t\treturn distanceFalloff;\n\t#else\n\t\tif ( cutoffDistance > 0.0 && decayExponent > 0.0 ) {\n\t\t\treturn pow( saturate( - lightDistance / cutoffDistance + 1.0 ), decayExponent );\n\t\t}\n\t\treturn 1.0;\n\t#endif\n}\nfloat getSpotAttenuation( const in float coneCosine, const in float penumbraCosine, const in float angleCosine ) {\n\treturn smoothstep( coneCosine, penumbraCosine, angleCosine );\n}\n#if NUM_DIR_LIGHTS > 0\n\tstruct DirectionalLight {\n\t\tvec3 direction;\n\t\tvec3 color;\n\t};\n\tuniform DirectionalLight directionalLights[ NUM_DIR_LIGHTS ];\n\tvoid getDirectionalLightInfo( const in DirectionalLight directionalLight, const in GeometricContext geometry, out IncidentLight light ) {\n\t\tlight.color = directionalLight.color;\n\t\tlight.direction = directionalLight.direction;\n\t\tlight.visible = true;\n\t}\n#endif\n#if NUM_POINT_LIGHTS > 0\n\tstruct PointLight {\n\t\tvec3 position;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t};\n\tuniform PointLight pointLights[ NUM_POINT_LIGHTS ];\n\tvoid getPointLightInfo( const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight light ) {\n\t\tvec3 lVector = pointLight.position - geometry.position;\n\t\tlight.direction = normalize( lVector );\n\t\tfloat lightDistance = length( lVector );\n\t\tlight.color = pointLight.color;\n\t\tlight.color *= getDistanceAttenuation( lightDistance, pointLight.distance, pointLight.decay );\n\t\tlight.visible = ( light.color != vec3( 0.0 ) );\n\t}\n#endif\n#if NUM_SPOT_LIGHTS > 0\n\tstruct SpotLight {\n\t\tvec3 position;\n\t\tvec3 direction;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t\tfloat coneCos;\n\t\tfloat penumbraCos;\n\t};\n\tuniform SpotLight spotLights[ NUM_SPOT_LIGHTS ];\n\tvoid getSpotLightInfo( const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight light ) {\n\t\tvec3 lVector = spotLight.position - geometry.position;\n\t\tlight.direction = normalize( lVector );\n\t\tfloat angleCos = dot( light.direction, spotLight.direction );\n\t\tfloat spotAttenuation = getSpotAttenuation( spotLight.coneCos, spotLight.penumbraCos, angleCos );\n\t\tif ( spotAttenuation > 0.0 ) {\n\t\t\tfloat lightDistance = length( lVector );\n\t\t\tlight.color = spotLight.color * spotAttenuation;\n\t\t\tlight.color *= getDistanceAttenuation( lightDistance, spotLight.distance, spotLight.decay );\n\t\t\tlight.visible = ( light.color != vec3( 0.0 ) );\n\t\t} else {\n\t\t\tlight.color = vec3( 0.0 );\n\t\t\tlight.visible = false;\n\t\t}\n\t}\n#endif\n#if NUM_RECT_AREA_LIGHTS > 0\n\tstruct RectAreaLight {\n\t\tvec3 color;\n\t\tvec3 position;\n\t\tvec3 halfWidth;\n\t\tvec3 halfHeight;\n\t};\n\tuniform sampler2D ltc_1;\tuniform sampler2D ltc_2;\n\tuniform RectAreaLight rectAreaLights[ NUM_RECT_AREA_LIGHTS ];\n#endif\n#if NUM_HEMI_LIGHTS > 0\n\tstruct HemisphereLight {\n\t\tvec3 direction;\n\t\tvec3 skyColor;\n\t\tvec3 groundColor;\n\t};\n\tuniform HemisphereLight hemisphereLights[ NUM_HEMI_LIGHTS ];\n\tvec3 getHemisphereLightIrradiance( const in HemisphereLight hemiLight, const in vec3 normal ) {\n\t\tfloat dotNL = dot( normal, hemiLight.direction );\n\t\tfloat hemiDiffuseWeight = 0.5 * dotNL + 0.5;\n\t\tvec3 irradiance = mix( hemiLight.groundColor, hemiLight.skyColor, hemiDiffuseWeight );\n\t\treturn irradiance;\n\t}\n#endif";
 
-var envmap_physical_pars_fragment = "#if defined( USE_ENVMAP )\n\t#ifdef ENVMAP_MODE_REFRACTION\n\t\tuniform float refractionRatio;\n\t#endif\n\tvec3 getIBLIrradiance( const in vec3 normal ) {\n\t\t#if defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec3 worldNormal = inverseTransformDirection( normal, viewMatrix );\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );\n\t\t\treturn PI * envMapColor.rgb * envMapIntensity;\n\t\t#else\n\t\t\treturn vec3( 0.0 );\n\t\t#endif\n\t}\n\tvec3 getIBLRadiance( const in vec3 viewDir, const in vec3 normal, const in float roughness ) {\n\t\t#if defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec3 reflectVec;\n\t\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\t\treflectVec = reflect( - viewDir, normal );\n\t\t\t\treflectVec = normalize( mix( reflectVec, normal, roughness * roughness) );\n\t\t\t#else\n\t\t\t\treflectVec = refract( - viewDir, normal, refractionRatio );\n\t\t\t#endif\n\t\t\treflectVec = inverseTransformDirection( reflectVec, viewMatrix );\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );\n\t\t\treturn envMapColor.rgb * envMapIntensity;\n\t\t#else\n\t\t\treturn vec3( 0.0 );\n\t\t#endif\n\t}\n#endif";
+var envmap_physical_pars_fragment = "#if defined( USE_ENVMAP )\n\t#ifdef ENVMAP_MODE_REFRACTION\n\t\tuniform float refractionRatio;\n\t#endif\n\tvec3 getIBLIrradiance( const in vec3 normal ) {\n\t\t#if defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec3 worldNormal = inverseTransformDirection( normal, viewMatrix );\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );\n\t\t\tvec4 envMap2Color = textureCubeUV( envMap2, worldNormal, 1.0 );\n\t\t\tenvMapColor = mix(envMapColor, envMap2Color, envMapBlend);\n\t\t\treturn PI * envMapColor.rgb * envMapIntensity;\n\t\t#else\n\t\t\treturn vec3( 0.0 );\n\t\t#endif\n\t}\n\tvec3 getIBLRadiance( const in vec3 viewDir, const in vec3 normal, const in float roughness ) {\n\t\t#if defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec3 reflectVec;\n\t\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\t\treflectVec = reflect( - viewDir, normal );\n\t\t\t\treflectVec = normalize( mix( reflectVec, normal, roughness * roughness) );\n\t\t\t#else\n\t\t\t\treflectVec = refract( - viewDir, normal, refractionRatio );\n\t\t\t#endif\n\t\t\treflectVec = inverseTransformDirection( reflectVec, viewMatrix );\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );\n\t\t\tvec4 envMap2Color = textureCubeUV( envMap2, reflectVec, roughness );\n\t\t\tenvMapColor = mix(envMapColor, envMap2Color, envMapBlend);\n\t\t\treturn envMapColor.rgb * envMapIntensity;\n\t\t#else\n\t\t\treturn vec3( 0.0 );\n\t\t#endif\n\t}\n#endif";
 
 var lights_toon_fragment = "ToonMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;";
 
@@ -19797,6 +19801,7 @@ function WebGLLights( extensions, capabilities ) {
 
 		ambient: [ 0, 0, 0 ],
 		probe: [],
+		reflectionProbes: [],
 		directional: [],
 		directionalShadow: [],
 		directionalShadowMap: [],
@@ -19838,6 +19843,8 @@ function WebGLLights( extensions, capabilities ) {
 		let numPointShadows = 0;
 		let numSpotShadows = 0;
 
+		let numReflectionProbes = 0;
+
 		lights.sort( shadowCastingLightsFirst );
 
 		// artist-friendly light intensity scaling factor
@@ -19866,6 +19873,10 @@ function WebGLLights( extensions, capabilities ) {
 					state.probe[ j ].addScaledVector( light.sh.coefficients[ j ], intensity );
 
 				}
+
+			} else if ( light.isReflectionProbe ) {
+
+				state.reflectionProbes[numReflectionProbes++] = light;
 
 			} else if ( light.isDirectionalLight ) {
 
@@ -20033,6 +20044,8 @@ function WebGLLights( extensions, capabilities ) {
 		state.ambient[ 0 ] = r;
 		state.ambient[ 1 ] = g;
 		state.ambient[ 2 ] = b;
+
+		state.reflectionProbes.length = numReflectionProbes;
 
 		const hash = state.hash;
 
@@ -25395,6 +25408,9 @@ function WebGLRenderer( parameters = {} ) {
 
 	const _vector3 = new Vector3();
 
+	const _tmpObjectAABB = new THREE.Box3();
+	const _tmpOverlapBox = new THREE.Box3();
+
 	const _emptyScene = { background: null, fog: null, environment: null, overrideMaterial: null, isScene: true };
 
 	function getTargetPixelRatio() {
@@ -26470,6 +26486,12 @@ function WebGLRenderer( parameters = {} ) {
 
 		currentRenderState.setupLightsView( camera );
 
+		// TODO this triggers cubemap generation up front, should probably be done elsewhere
+		const reflectionProbes = currentRenderState.state.lights.state.reflectionProbes;
+		for(let i = 0; i<reflectionProbes.length; i++) {
+			cubeuvmaps.get(reflectionProbes[i].texture);
+		}
+
 		if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, scene, camera );
 
 		if ( viewport ) state.viewport( _currentViewport.copy( viewport ) );
@@ -27018,6 +27040,67 @@ function WebGLRenderer( parameters = {} ) {
 
 			p_uniforms.setValue( _gl, 'center', object.center );
 
+		}
+
+		if(materialProperties.envMap && material.isMeshStandardMaterial) {
+			if(object.reflectionProbeMode === "static" && object.__webglStaticReflectionProbe) {
+				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
+				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
+				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
+			} else if(object.reflectionProbeMode) {
+				if(!geometry.boundingBox) {
+					console.log("generated bounding box for ", object.name);
+					geometry.computeBoundingBox();
+				}
+
+				_tmpObjectAABB.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld);
+
+				let envMapA = null;
+				let envMapB = null;
+				let maxVolumeA = 0;
+				let maxVolumeB = 0;
+
+				// TODO maybe move probes to render state, collect at the same time we collect lights
+				const probes = lights.state.reflectionProbes;
+				for(let i = 0; i< probes.length; i++) {
+					if(probes[i].box.intersectsBox(_tmpObjectAABB)) {
+						const volume = _tmpOverlapBox.copy(_tmpObjectAABB).intersect(probes[i].box).volume();
+						if(volume > maxVolumeA) {
+							envMapB = envMapA;
+							maxVolumeB = maxVolumeA;
+							envMapA = probes[i].texture;
+							maxVolumeA = volume;
+						} else if(volume > maxVolumeB) {
+							envMapB = probes[i].texture;
+							maxVolumeB = volume;
+						}
+					}
+				}
+
+				const blend = envMapB ?
+					maxVolumeB / (maxVolumeA + maxVolumeB) : 
+					1 - (maxVolumeA / _tmpObjectAABB.volume());
+
+				envMapA = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapA || environment );
+				envMapB = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapB || environment );
+
+				p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
+				p_uniforms.setValue( _gl, 'envMap2', envMapB, textures );
+				p_uniforms.setValue( _gl, 'envMapBlend', blend );
+
+				if(object.reflectionProbeMode === "static") {
+					object.__webglStaticReflectionProbe = {
+						envMap: envMapA,
+						envMap2: envMapB,
+						envMapBlend: blend
+					};
+				}
+
+			} else {
+				// p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
+				p_uniforms.setValue( _gl, 'envMap2', null, textures);
+				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
+			}
 		}
 
 		// common matrices
@@ -42159,6 +42242,34 @@ class AmbientLightProbe extends LightProbe {
 
 AmbientLightProbe.prototype.isAmbientLightProbe = true;
 
+class ReflectionProbe extends Light {
+
+	constructor( box = new Box3(), texture) {
+
+		super();
+
+		this.box = box;
+		this.texture = texture;
+
+	}
+
+	copy( source ) {
+
+		super.copy( source );
+
+		this.box.copy( source.box );
+		this.texture = source.texture;
+
+		return this;
+
+	}
+
+	// TODO fromJSON/toJSON
+
+}
+
+ReflectionProbe.prototype.isReflectionProbe = true;
+
 const _eyeRight = /*@__PURE__*/ new Matrix4();
 const _eyeLeft = /*@__PURE__*/ new Matrix4();
 
@@ -49952,4 +50063,5 @@ if ( typeof window !== 'undefined' ) {
 
 }
 
-export { ACESFilmicToneMapping, AddEquation, AddOperation, AdditiveAnimationBlendMode, AdditiveBlending, AlphaFormat, AlwaysDepth, AlwaysStencilFunc, AmbientLight, AmbientLightProbe, AnimationClip, AnimationLoader, AnimationMixer, AnimationObjectGroup, AnimationUtils, ArcCurve, ArrayCamera, ArrowHelper, Audio, AudioAnalyser, AudioContext, AudioListener, AudioLoader, AxesHelper, AxisHelper, BackSide, BasicDepthPacking, BasicShadowMap, BinaryTextureLoader, Bone, BooleanKeyframeTrack, BoundingBoxHelper, Box2, Box3, Box3Helper, BoxGeometry as BoxBufferGeometry, BoxGeometry, BoxHelper, BufferAttribute, BufferGeometry, BufferGeometryLoader, ByteType, Cache, Camera, CameraHelper, CanvasRenderer, CanvasTexture, CatmullRomCurve3, CineonToneMapping, CircleGeometry as CircleBufferGeometry, CircleGeometry, ClampToEdgeWrapping, Clock, Color, ColorKeyframeTrack, CompressedTexture, CompressedTextureLoader, ConeGeometry as ConeBufferGeometry, ConeGeometry, CubeCamera, CubeReflectionMapping, CubeRefractionMapping, CubeTexture, CubeTextureLoader, CubeUVReflectionMapping, CubeUVRefractionMapping, CubicBezierCurve, CubicBezierCurve3, CubicInterpolant, CullFaceBack, CullFaceFront, CullFaceFrontBack, CullFaceNone, Curve, CurvePath, CustomBlending, CustomToneMapping, CylinderGeometry as CylinderBufferGeometry, CylinderGeometry, Cylindrical, DataTexture, DataTexture2DArray, DataTexture3D, DataTextureLoader, DataUtils, DecrementStencilOp, DecrementWrapStencilOp, DefaultLoadingManager, DepthFormat, DepthStencilFormat, DepthTexture, DirectionalLight, DirectionalLightHelper, DiscreteInterpolant, DodecahedronGeometry as DodecahedronBufferGeometry, DodecahedronGeometry, DoubleSide, DstAlphaFactor, DstColorFactor, DynamicBufferAttribute, DynamicCopyUsage, DynamicDrawUsage, DynamicReadUsage, EdgesGeometry, EdgesHelper, EllipseCurve, EqualDepth, EqualStencilFunc, EquirectangularReflectionMapping, EquirectangularRefractionMapping, Euler, EventDispatcher, ExtrudeGeometry as ExtrudeBufferGeometry, ExtrudeGeometry, FaceColors, FileLoader, FlatShading, Float16BufferAttribute, Float32Attribute, Float32BufferAttribute, Float64Attribute, Float64BufferAttribute, FloatType, Fog, FogExp2, Font, FontLoader, FrontSide, Frustum, GLBufferAttribute, GLSL1, GLSL3, GammaEncoding, GreaterDepth, GreaterEqualDepth, GreaterEqualStencilFunc, GreaterStencilFunc, GridHelper, Group, HalfFloatType, HemisphereLight, HemisphereLightHelper, HemisphereLightProbe, IcosahedronGeometry as IcosahedronBufferGeometry, IcosahedronGeometry, ImageBitmapLoader, ImageLoader, ImageUtils, ImmediateRenderObject, IncrementStencilOp, IncrementWrapStencilOp, InstancedBufferAttribute, InstancedBufferGeometry, InstancedInterleavedBuffer, InstancedMesh, Int16Attribute, Int16BufferAttribute, Int32Attribute, Int32BufferAttribute, Int8Attribute, Int8BufferAttribute, IntType, InterleavedBuffer, InterleavedBufferAttribute, Interpolant, InterpolateDiscrete, InterpolateLinear, InterpolateSmooth, InvertStencilOp, JSONLoader, KeepStencilOp, KeyframeTrack, LOD, LUTToneMapping, LatheGeometry as LatheBufferGeometry, LatheGeometry, Layers, LensFlare, LessDepth, LessEqualDepth, LessEqualStencilFunc, LessStencilFunc, Light, LightProbe, Line, Line3, LineBasicMaterial, LineCurve, LineCurve3, LineDashedMaterial, LineLoop, LinePieces, LineSegments, LineStrip, LinearEncoding, LinearFilter, LinearInterpolant, LinearMipMapLinearFilter, LinearMipMapNearestFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, LinearToneMapping, Loader, LoaderUtils, LoadingManager, LogLuvEncoding, LoopOnce, LoopPingPong, LoopRepeat, LuminanceAlphaFormat, LuminanceFormat, MOUSE, Material, MaterialLoader, MathUtils as Math, MathUtils, Matrix3, Matrix4, MaxEquation, Mesh, MeshBasicMaterial, MeshDepthMaterial, MeshDistanceMaterial, MeshFaceMaterial, MeshLambertMaterial, MeshMatcapMaterial, MeshNormalMaterial, MeshPhongMaterial, MeshPhysicalMaterial, MeshStandardMaterial, MeshToonMaterial, MinEquation, MirroredRepeatWrapping, MixOperation, MultiMaterial, MultiplyBlending, MultiplyOperation, NearestFilter, NearestMipMapLinearFilter, NearestMipMapNearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, NeverDepth, NeverStencilFunc, NoBlending, NoColors, NoToneMapping, NormalAnimationBlendMode, NormalBlending, NotEqualDepth, NotEqualStencilFunc, NumberKeyframeTrack, Object3D, ObjectLoader, ObjectSpaceNormalMap, OctahedronGeometry as OctahedronBufferGeometry, OctahedronGeometry, OneFactor, OneMinusDstAlphaFactor, OneMinusDstColorFactor, OneMinusSrcAlphaFactor, OneMinusSrcColorFactor, OrthographicCamera, PCFShadowMap, PCFSoftShadowMap, PMREMGenerator, ParametricGeometry, Particle, ParticleBasicMaterial, ParticleSystem, ParticleSystemMaterial, Path, PerspectiveCamera, Plane, PlaneGeometry as PlaneBufferGeometry, PlaneGeometry, PlaneHelper, PointCloud, PointCloudMaterial, PointLight, PointLightHelper, Points, PointsMaterial, PolarGridHelper, PolyhedronGeometry as PolyhedronBufferGeometry, PolyhedronGeometry, PositionalAudio, PropertyBinding, PropertyMixer, QuadraticBezierCurve, QuadraticBezierCurve3, Quaternion, QuaternionKeyframeTrack, QuaternionLinearInterpolant, REVISION, RGBADepthPacking, RGBAFormat, RGBAIntegerFormat, RGBA_ASTC_10x10_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_BPTC_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT1_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT5_Format, RGBDEncoding, RGBEEncoding, RGBEFormat, RGBFormat, RGBIntegerFormat, RGBM16Encoding, RGBM7Encoding, RGB_ETC1_Format, RGB_ETC2_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGB_S3TC_DXT1_Format, RGFormat, RGIntegerFormat, RawShaderMaterial, Ray, Raycaster, RectAreaLight, RedFormat, RedIntegerFormat, ReinhardToneMapping, RepeatWrapping, ReplaceStencilOp, ReverseSubtractEquation, RingGeometry as RingBufferGeometry, RingGeometry, SRGB8_ALPHA8_ASTC_10x10_Format, SRGB8_ALPHA8_ASTC_10x5_Format, SRGB8_ALPHA8_ASTC_10x6_Format, SRGB8_ALPHA8_ASTC_10x8_Format, SRGB8_ALPHA8_ASTC_12x10_Format, SRGB8_ALPHA8_ASTC_12x12_Format, SRGB8_ALPHA8_ASTC_4x4_Format, SRGB8_ALPHA8_ASTC_5x4_Format, SRGB8_ALPHA8_ASTC_5x5_Format, SRGB8_ALPHA8_ASTC_6x5_Format, SRGB8_ALPHA8_ASTC_6x6_Format, SRGB8_ALPHA8_ASTC_8x5_Format, SRGB8_ALPHA8_ASTC_8x6_Format, SRGB8_ALPHA8_ASTC_8x8_Format, Scene, SceneUtils, ShaderChunk, ShaderLib, ShaderMaterial, ShadowMaterial, Shape, ShapeGeometry as ShapeBufferGeometry, ShapeGeometry, ShapePath, ShapeUtils, ShortType, Skeleton, SkeletonHelper, SkinnedMesh, SmoothShading, Sphere, SphereGeometry as SphereBufferGeometry, SphereGeometry, Spherical, SphericalHarmonics3, SplineCurve, SpotLight, SpotLightHelper, Sprite, SpriteMaterial, SrcAlphaFactor, SrcAlphaSaturateFactor, SrcColorFactor, StaticCopyUsage, StaticDrawUsage, StaticReadUsage, StereoCamera, StreamCopyUsage, StreamDrawUsage, StreamReadUsage, StringKeyframeTrack, SubtractEquation, SubtractiveBlending, TOUCH, TangentSpaceNormalMap, TetrahedronGeometry as TetrahedronBufferGeometry, TetrahedronGeometry, TextGeometry, Texture, TextureLoader, TorusGeometry as TorusBufferGeometry, TorusGeometry, TorusKnotGeometry as TorusKnotBufferGeometry, TorusKnotGeometry, Triangle, TriangleFanDrawMode, TriangleStripDrawMode, TrianglesDrawMode, TubeGeometry as TubeBufferGeometry, TubeGeometry, UVMapping, Uint16Attribute, Uint16BufferAttribute, Uint32Attribute, Uint32BufferAttribute, Uint8Attribute, Uint8BufferAttribute, Uint8ClampedAttribute, Uint8ClampedBufferAttribute, Uniform, UniformsLib, UniformsUtils, UnsignedByteType, UnsignedInt248Type, UnsignedIntType, UnsignedShort4444Type, UnsignedShort5551Type, UnsignedShort565Type, UnsignedShortType, VSMShadowMap, Vector2, Vector3, Vector4, VectorKeyframeTrack, Vertex, VertexColors, VideoTexture, WebGL1Renderer, WebGLCubeRenderTarget, WebGLMultipleRenderTargets, WebGLMultisampleRenderTarget, WebGLRenderTarget, WebGLRenderTargetCube, WebGLRenderer, WebGLUtils, WireframeGeometry, WireframeHelper, WrapAroundEnding, XHRLoader, ZeroCurvatureEnding, ZeroFactor, ZeroSlopeEnding, ZeroStencilOp, sRGBEncoding };
+export { ACESFilmicToneMapping, AddEquation, AddOperation, AdditiveAnimationBlendMode, AdditiveBlending, AlphaFormat, AlwaysDepth, AlwaysStencilFunc, AmbientLight, AmbientLightProbe, AnimationClip, AnimationLoader, AnimationMixer, AnimationObjectGroup, AnimationUtils, ArcCurve, ArrayCamera, ArrowHelper, Audio, AudioAnalyser, AudioContext, AudioListener, AudioLoader, AxesHelper, AxisHelper, BackSide, BasicDepthPacking, BasicShadowMap, BinaryTextureLoader, Bone, BooleanKeyframeTrack, BoundingBoxHelper, Box2, Box3, Box3Helper, BoxGeometry as BoxBufferGeometry, BoxGeometry, BoxHelper, BufferAttribute, BufferGeometry, BufferGeometryLoader, ByteType, Cache, Camera, CameraHelper, CanvasRenderer, CanvasTexture, CatmullRomCurve3, CineonToneMapping, CircleGeometry as CircleBufferGeometry, CircleGeometry, ClampToEdgeWrapping, Clock, Color, ColorKeyframeTrack, CompressedTexture, CompressedTextureLoader, ConeGeometry as ConeBufferGeometry, ConeGeometry, CubeCamera, CubeReflectionMapping, CubeRefractionMapping, CubeTexture, CubeTextureLoader, CubeUVReflectionMapping, CubeUVRefractionMapping, CubicBezierCurve, CubicBezierCurve3, CubicInterpolant, CullFaceBack, CullFaceFront, CullFaceFrontBack, CullFaceNone, Curve, CurvePath, CustomBlending, CustomToneMapping, CylinderGeometry as CylinderBufferGeometry, CylinderGeometry, Cylindrical, DataTexture, DataTexture2DArray, DataTexture3D, DataTextureLoader, DataUtils, DecrementStencilOp, DecrementWrapStencilOp, DefaultLoadingManager, DepthFormat, DepthStencilFormat, DepthTexture, DirectionalLight, DirectionalLightHelper, DiscreteInterpolant, DodecahedronGeometry as DodecahedronBufferGeometry, DodecahedronGeometry, DoubleSide, DstAlphaFactor, DstColorFactor, DynamicBufferAttribute, DynamicCopyUsage, DynamicDrawUsage, DynamicReadUsage, EdgesGeometry, EdgesHelper, EllipseCurve, EqualDepth, EqualStencilFunc, EquirectangularReflectionMapping, EquirectangularRefractionMapping, Euler, EventDispatcher, ExtrudeGeometry as ExtrudeBufferGeometry, ExtrudeGeometry, FaceColors, FileLoader, FlatShading, Float16BufferAttribute, Float32Attribute, Float32BufferAttribute, Float64Attribute, Float64BufferAttribute, FloatType, Fog, FogExp2, Font, FontLoader, FrontSide, Frustum, GLBufferAttribute, GLSL1, GLSL3, GammaEncoding, GreaterDepth, GreaterEqualDepth, GreaterEqualStencilFunc, GreaterStencilFunc, GridHelper, Group, HalfFloatType, HemisphereLight, HemisphereLightHelper, HemisphereLightProbe, IcosahedronGeometry as IcosahedronBufferGeometry, IcosahedronGeometry, ImageBitmapLoader, ImageLoader, ImageUtils, ImmediateRenderObject, IncrementStencilOp, IncrementWrapStencilOp, InstancedBufferAttribute, InstancedBufferGeometry, InstancedInterleavedBuffer, InstancedMesh, Int16Attribute, Int16BufferAttribute, Int32Attribute, Int32BufferAttribute, Int8Attribute, Int8BufferAttribute, IntType, InterleavedBuffer, InterleavedBufferAttribute, Interpolant, InterpolateDiscrete, InterpolateLinear, InterpolateSmooth, InvertStencilOp, JSONLoader, KeepStencilOp, KeyframeTrack, LOD, LUTToneMapping, LatheGeometry as LatheBufferGeometry, LatheGeometry, Layers, LensFlare, LessDepth, LessEqualDepth, LessEqualStencilFunc, LessStencilFunc, Light, LightProbe, Line, Line3, LineBasicMaterial, LineCurve, LineCurve3, LineDashedMaterial, LineLoop, LinePieces, LineSegments, LineStrip, LinearEncoding, LinearFilter, LinearInterpolant, LinearMipMapLinearFilter, LinearMipMapNearestFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, LinearToneMapping, Loader, LoaderUtils, LoadingManager, LogLuvEncoding, LoopOnce, LoopPingPong, LoopRepeat, LuminanceAlphaFormat, LuminanceFormat, MOUSE, Material, MaterialLoader, MathUtils as Math, MathUtils, Matrix3, Matrix4, MaxEquation, Mesh, MeshBasicMaterial, MeshDepthMaterial, MeshDistanceMaterial, MeshFaceMaterial, MeshLambertMaterial, MeshMatcapMaterial, MeshNormalMaterial, MeshPhongMaterial, MeshPhysicalMaterial, MeshStandardMaterial, MeshToonMaterial, MinEquation, MirroredRepeatWrapping, MixOperation, MultiMaterial, MultiplyBlending, MultiplyOperation, NearestFilter, NearestMipMapLinearFilter, NearestMipMapNearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, NeverDepth, NeverStencilFunc, NoBlending, NoColors, NoToneMapping, NormalAnimationBlendMode, NormalBlending, NotEqualDepth, NotEqualStencilFunc, NumberKeyframeTrack, Object3D, ObjectLoader, ObjectSpaceNormalMap, OctahedronGeometry as OctahedronBufferGeometry, OctahedronGeometry, OneFactor, OneMinusDstAlphaFactor, OneMinusDstColorFactor, OneMinusSrcAlphaFactor, OneMinusSrcColorFactor, OrthographicCamera, PCFShadowMap, PCFSoftShadowMap, PMREMGenerator, ParametricGeometry, Particle, ParticleBasicMaterial, ParticleSystem, ParticleSystemMaterial, Path, PerspectiveCamera, Plane, PlaneGeometry as PlaneBufferGeometry, PlaneGeometry, PlaneHelper, PointCloud, PointCloudMaterial, PointLight, PointLightHelper, Points, PointsMaterial, PolarGridHelper, PolyhedronGeometry as PolyhedronBufferGeometry, PolyhedronGeometry, PositionalAudio, PropertyBinding, PropertyMixer, QuadraticBezierCurve, QuadraticBezierCurve3, Quaternion, QuaternionKeyframeTrack, QuaternionLinearInterpolant, REVISION, RGBADepthPacking, RGBAFormat, RGBAIntegerFormat, RGBA_ASTC_10x10_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_BPTC_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT1_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT5_Format, RGBDEncoding, RGBEEncoding, RGBEFormat, RGBFormat, RGBIntegerFormat, RGBM16Encoding, RGBM7Encoding, RGB_ETC1_Format, RGB_ETC2_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGB_S3TC_DXT1_Format, RGFormat, RGIntegerFormat, RawShaderMaterial, Ray, Raycaster, RectAreaLight, RedFormat, RedIntegerFormat, ReflectionProbe, ReinhardToneMapping, RepeatWrapping, ReplaceStencilOp, ReverseSubtractEquation, RingGeometry as RingBufferGeometry, RingGeometry, SRGB8_ALPHA8_ASTC_10x10_Format, SRGB8_ALPHA8_ASTC_10x5_Format, SRGB8_ALPHA8_ASTC_10x6_Format, SRGB8_ALPHA8_ASTC_10x8_Format, SRGB8_ALPHA8_ASTC_12x10_Format, SRGB8_ALPHA8_ASTC_12x12_Format, SRGB8_ALPHA8_ASTC_4x4_Format, SRGB8_ALPHA8_ASTC_5x4_Format, SRGB8_ALPHA8_ASTC_5x5_Format, SRGB8_ALPHA8_ASTC_6x5_Format, SRGB8_ALPHA8_ASTC_6x6_Format, SRGB8_ALPHA8_ASTC_8x5_Format, SRGB8_ALPHA8_ASTC_8x6_Format, SRGB8_ALPHA8_ASTC_8x8_Format, Scene, SceneUtils, ShaderChunk, ShaderLib, ShaderMaterial, ShadowMaterial, Shape, ShapeGeometry as ShapeBufferGeometry, ShapeGeometry, ShapePath, ShapeUtils, ShortType, Skeleton, SkeletonHelper, SkinnedMesh, SmoothShading, Sphere, SphereGeometry as SphereBufferGeometry, SphereGeometry, Spherical, SphericalHarmonics3, SplineCurve, SpotLight, SpotLightHelper, Sprite, SpriteMaterial, SrcAlphaFactor, SrcAlphaSaturateFactor, SrcColorFactor, StaticCopyUsage, StaticDrawUsage, StaticReadUsage, StereoCamera, StreamCopyUsage, StreamDrawUsage, StreamReadUsage, StringKeyframeTrack, SubtractEquation, SubtractiveBlending, TOUCH, TangentSpaceNormalMap, TetrahedronGeometry as TetrahedronBufferGeometry, TetrahedronGeometry, TextGeometry, Texture, TextureLoader, TorusGeometry as TorusBufferGeometry, TorusGeometry, TorusKnotGeometry as TorusKnotBufferGeometry, TorusKnotGeometry, Triangle, TriangleFanDrawMode, TriangleStripDrawMode, TrianglesDrawMode, TubeGeometry as TubeBufferGeometry, TubeGeometry, UVMapping, Uint16Attribute, Uint16BufferAttribute, Uint32Attribute, Uint32BufferAttribute, Uint8Attribute, Uint8BufferAttribute, Uint8ClampedAttribute, Uint8ClampedBufferAttribute, Uniform, UniformsLib, UniformsUtils, UnsignedByteType, UnsignedInt248Type, UnsignedIntType, UnsignedShort4444Type, UnsignedShort5551Type, UnsignedShort565Type, UnsignedShortType, VSMShadowMap, Vector2, Vector3, Vector4, VectorKeyframeTrack, Vertex, VertexColors, VideoTexture, WebGL1Renderer, WebGLCubeRenderTarget, WebGLMultipleRenderTargets, WebGLMultisampleRenderTarget, WebGLRenderTarget, WebGLRenderTargetCube, WebGLRenderer, WebGLUtils, WireframeGeometry, WireframeHelper, WrapAroundEnding, XHRLoader, ZeroCurvatureEnding, ZeroFactor, ZeroSlopeEnding, ZeroStencilOp, sRGBEncoding };
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGhyZWUubW9kdWxlLmpzIiwic291cmNlcyI6W10sInNvdXJjZXNDb250ZW50IjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiJ9

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -26981,6 +26981,68 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
+        // Similar to note about skinned meshes above, this must be done before other texture uploads otherwise the texture units might overlap
+		if(materialProperties.envMap && material.isMeshStandardMaterial) {
+			if(object.reflectionProbeMode === "static" && object.__webglStaticReflectionProbe) {
+				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
+				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
+				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
+			} else if(object.reflectionProbeMode) {
+				if(!geometry.boundingBox) {
+					console.log("generated bounding box for ", object.name);
+					geometry.computeBoundingBox();
+				}
+
+				_tmpObjectAABB.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld);
+
+				let envMapA = null;
+				let envMapB = null;
+				let maxVolumeA = 0;
+				let maxVolumeB = 0;
+
+				// TODO maybe move probes to render state, collect at the same time we collect lights
+				const probes = lights.state.reflectionProbes;
+				for(let i = 0; i< probes.length; i++) {
+					if(probes[i].box.intersectsBox(_tmpObjectAABB)) {
+						const volume = _tmpOverlapBox.copy(_tmpObjectAABB).intersect(probes[i].box).volume();
+						if(volume > maxVolumeA) {
+							envMapB = envMapA;
+							maxVolumeB = maxVolumeA;
+							envMapA = probes[i].texture;
+							maxVolumeA = volume;
+						} else if(volume > maxVolumeB) {
+							envMapB = probes[i].texture;
+							maxVolumeB = volume;
+						}
+					}
+				}
+
+				const blend = envMapB ?
+					maxVolumeB / (maxVolumeA + maxVolumeB) : 
+					1 - (maxVolumeA / _tmpObjectAABB.volume());
+
+				envMapA = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapA || environment );
+				envMapB = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapB || environment );
+
+				p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
+				p_uniforms.setValue( _gl, 'envMap2', envMapB, textures );
+				p_uniforms.setValue( _gl, 'envMapBlend', blend );
+
+				if(object.reflectionProbeMode === "static") {
+					object.__webglStaticReflectionProbe = {
+						envMap: envMapA,
+						envMap2: envMapB,
+						envMapBlend: blend
+					};
+				}
+			} else {
+				// p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
+				p_uniforms.setValue( _gl, 'envMap2', cubeuvmaps.get(scene.environment), textures);
+				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
+                
+			}
+		}
+
 		if ( !! geometry && ( geometry.morphAttributes.position !== undefined || geometry.morphAttributes.normal !== undefined ) ) {
 
 			morphtargets.update( object, geometry, material, program );
@@ -27040,67 +27102,6 @@ function WebGLRenderer( parameters = {} ) {
 
 			p_uniforms.setValue( _gl, 'center', object.center );
 
-		}
-
-		if(materialProperties.envMap && material.isMeshStandardMaterial) {
-			if(object.reflectionProbeMode === "static" && object.__webglStaticReflectionProbe) {
-				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
-				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
-				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
-			} else if(object.reflectionProbeMode) {
-				if(!geometry.boundingBox) {
-					console.log("generated bounding box for ", object.name);
-					geometry.computeBoundingBox();
-				}
-
-				_tmpObjectAABB.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld);
-
-				let envMapA = null;
-				let envMapB = null;
-				let maxVolumeA = 0;
-				let maxVolumeB = 0;
-
-				// TODO maybe move probes to render state, collect at the same time we collect lights
-				const probes = lights.state.reflectionProbes;
-				for(let i = 0; i< probes.length; i++) {
-					if(probes[i].box.intersectsBox(_tmpObjectAABB)) {
-						const volume = _tmpOverlapBox.copy(_tmpObjectAABB).intersect(probes[i].box).volume();
-						if(volume > maxVolumeA) {
-							envMapB = envMapA;
-							maxVolumeB = maxVolumeA;
-							envMapA = probes[i].texture;
-							maxVolumeA = volume;
-						} else if(volume > maxVolumeB) {
-							envMapB = probes[i].texture;
-							maxVolumeB = volume;
-						}
-					}
-				}
-
-				const blend = envMapB ?
-					maxVolumeB / (maxVolumeA + maxVolumeB) : 
-					1 - (maxVolumeA / _tmpObjectAABB.volume());
-
-				envMapA = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapA || environment );
-				envMapB = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapB || environment );
-
-				p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
-				p_uniforms.setValue( _gl, 'envMap2', envMapB, textures );
-				p_uniforms.setValue( _gl, 'envMapBlend', blend );
-
-				if(object.reflectionProbeMode === "static") {
-					object.__webglStaticReflectionProbe = {
-						envMap: envMapA,
-						envMap2: envMapB,
-						envMapBlend: blend
-					};
-				}
-
-			} else {
-				// p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
-				p_uniforms.setValue( _gl, 'envMap2', null, textures);
-				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
-			}
 		}
 
 		// common matrices

--- a/src/Three.js
+++ b/src/Three.js
@@ -62,6 +62,7 @@ export { AmbientLight } from './lights/AmbientLight.js';
 export { AmbientLightProbe } from './lights/AmbientLightProbe.js';
 export { Light } from './lights/Light.js';
 export { LightProbe } from './lights/LightProbe.js';
+export { ReflectionProbe } from './lights/ReflectionProbe.js';
 export { StereoCamera } from './cameras/StereoCamera.js';
 export { PerspectiveCamera } from './cameras/PerspectiveCamera.js';
 export { OrthographicCamera } from './cameras/OrthographicCamera.js';

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -109,6 +109,7 @@ class Object3D extends EventDispatcher {
 
 		this.castShadow = false;
 		this.receiveShadow = false;
+		this.reflectionProbeMode = false;
 
 		this.frustumCulled = true;
 		this.renderOrder = 0;

--- a/src/lights/ReflectionProbe.js
+++ b/src/lights/ReflectionProbe.js
@@ -3,7 +3,7 @@ import { Light } from './Light.js';
 
 class ReflectionProbe extends Light {
 
-	constructor( box = new Box3(), texture) {
+	constructor( box = new Box3(), texture ) {
 
 		super();
 

--- a/src/lights/ReflectionProbe.js
+++ b/src/lights/ReflectionProbe.js
@@ -1,0 +1,32 @@
+import { Box3 } from '../math/Box3.js';
+import { Light } from './Light.js';
+
+class ReflectionProbe extends Light {
+
+	constructor( box = new Box3(), texture) {
+
+		super();
+
+		this.box = box;
+		this.texture = texture;
+
+	}
+
+	copy( source ) {
+
+		super.copy( source );
+
+		this.box.copy( source.box );
+		this.texture = source.texture;
+
+		return this;
+
+	}
+
+	// TODO fromJSON/toJSON
+
+}
+
+ReflectionProbe.prototype.isReflectionProbe = true;
+
+export { ReflectionProbe };

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -10,7 +10,9 @@ class Box3 {
 	}
 
 	volume() {
-		return ((this.max.x - this.min.x) * (this.max.y - this.min.y) * (this.max.z - this.min.z));
+
+		return ( ( this.max.x - this.min.x ) * ( this.max.y - this.min.y ) * ( this.max.z - this.min.z ) );
+
 	}
 
 	set( min, max ) {

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -9,6 +9,10 @@ class Box3 {
 
 	}
 
+	volume() {
+		return ((this.max.x - this.min.x) * (this.max.y - this.min.y) * (this.max.z - this.min.z));
+	}
+
 	set( min, max ) {
 
 		this.min.copy( min );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1256,8 +1256,10 @@ function WebGLRenderer( parameters = {} ) {
 
 		// TODO this triggers cubemap generation up front, should probably be done elsewhere
 		const reflectionProbes = currentRenderState.state.lights.state.reflectionProbes;
-		for(let i = 0; i<reflectionProbes.length; i++) {
-			cubeuvmaps.get(reflectionProbes[i].texture);
+		for ( let i = 0; i < reflectionProbes.length; i ++ ) {
+
+			cubeuvmaps.get( reflectionProbes[ i ].texture );
+
 		}
 
 		if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, scene, camera );
@@ -1809,20 +1811,20 @@ function WebGLRenderer( parameters = {} ) {
 				p_uniforms.setValue( _gl, 'envMap2', envMapB, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', blend );
 
-				if(object.reflectionProbeMode === 'static') {
+				if ( object.reflectionProbeMode === 'static' ) {
 
 					object.__webglStaticReflectionProbe = {
 						envMap: envMapA,
 						envMap2: envMapB,
 						envMapBlend: blend
-					}
+					};
 
 				}
 
 			} else {
 
 				// p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
-				p_uniforms.setValue( _gl, 'envMap2', cubeuvmaps.get(scene.environment), textures);
+				p_uniforms.setValue( _gl, 'envMap2', cubeuvmaps.get( scene.environment ), textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
 
 			}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1758,7 +1758,8 @@ function WebGLRenderer( parameters = {} ) {
 
 			if ( object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
 
-				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
+				envMapA = object.__webglStaticReflectionProbe.envMap;
+				p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
 				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -16,6 +16,7 @@ import { Frustum } from '../math/Frustum.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
+import { Box3 } from '../math/Box3.js';
 import { WebGLAnimation } from './webgl/WebGLAnimation.js';
 import { WebGLAttributes } from './webgl/WebGLAttributes.js';
 import { WebGLBackground } from './webgl/WebGLBackground.js';
@@ -176,8 +177,8 @@ function WebGLRenderer( parameters = {} ) {
 
 	const _vector3 = new Vector3();
 
-	const _tmpObjectAABB = new THREE.Box3();
-	const _tmpOverlapBox = new THREE.Box3();
+	const _tmpObjectAABB = new Box3();
+	const _tmpOverlapBox = new Box3();
 
 	const _emptyScene = { background: null, fog: null, environment: null, overrideMaterial: null, isScene: true };
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1757,13 +1757,13 @@ function WebGLRenderer( parameters = {} ) {
 		// be set in all cases to prevent texture units from becoming out of sync when refreshMaterials is not set.
 		if ( materialProperties.envMap && material.isMeshStandardMaterial ) {
 
-			if ( object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
+			if ( ! material.envMap && object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
 
 				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
 				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
 
-			} else if ( object.reflectionProbeMode ) {
+			} else if ( ! material.envMap && object.reflectionProbeMode ) {
 
 				if ( ! geometry.boundingBox ) {
 
@@ -1826,9 +1826,8 @@ function WebGLRenderer( parameters = {} ) {
 
 			} else {
 
-				const defaultEnv = cubeuvmaps.get( scene.environment );
-				p_uniforms.setValue( _gl, 'envMap', defaultEnv, textures );
-				p_uniforms.setValue( _gl, 'envMap2', defaultEnv, textures );
+				p_uniforms.setValue( _gl, 'envMap', materialProperties.envMap, textures );
+				p_uniforms.setValue( _gl, 'envMap2', materialProperties.envMap, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
 
 			}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1749,45 +1749,58 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-        // Similar to note about skinned meshes above, this must be done before other texture uploads otherwise the texture units might overlap
+		// Similar to note about skinned meshes above, this must be done before other texture uploads otherwise the texture units might overlap
 		let envMapA = null;
-		if(materialProperties.envMap && material.isMeshStandardMaterial) {
-			if(object.reflectionProbeMode === "static" && object.__webglStaticReflectionProbe) {
+		if ( materialProperties.envMap && material.isMeshStandardMaterial ) {
+
+			if ( object.reflectionProbeMode === 'static' && object.__webglStaticReflectionProbe ) {
+
 				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
 				p_uniforms.setValue( _gl, 'envMap2', object.__webglStaticReflectionProbe.envMap2, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', object.__webglStaticReflectionProbe.envMapBlend );
-			} else if(object.reflectionProbeMode) {
-				if(!geometry.boundingBox) {
-					console.log("generated bounding box for ", object.name)
+
+			} else if ( object.reflectionProbeMode ) {
+
+				if ( ! geometry.boundingBox ) {
+
+					console.log( 'generated bounding box for ', object.name );
 					geometry.computeBoundingBox();
+
 				}
 
-				_tmpObjectAABB.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld);
+				_tmpObjectAABB.copy( geometry.boundingBox ).applyMatrix4( object.matrixWorld );
 
 				let envMapB = null;
 				let maxVolumeA = 0;
 				let maxVolumeB = 0;
 
-				// TODO maybe move probes to render state, collect at the same time we collect lights
-				const probes = lights.state.reflectionProbes
-				for(let i = 0; i< probes.length; i++) {
-					if(probes[i].box.intersectsBox(_tmpObjectAABB)) {
-						const volume = _tmpOverlapBox.copy(_tmpObjectAABB).intersect(probes[i].box).volume()
-						if(volume > maxVolumeA) {
+				const probes = lights.state.reflectionProbes;
+				for ( let i = 0; i < probes.length; i ++ ) {
+
+					if ( probes[ i ].box.intersectsBox( _tmpObjectAABB ) ) {
+
+						const volume = _tmpOverlapBox.copy( _tmpObjectAABB ).intersect( probes[ i ].box ).volume();
+						if ( volume > maxVolumeA ) {
+
 							envMapB = envMapA;
 							maxVolumeB = maxVolumeA;
-							envMapA = probes[i].texture;
+							envMapA = probes[ i ].texture;
 							maxVolumeA = volume;
-						} else if(volume > maxVolumeB) {
-							envMapB = probes[i].texture;
+
+						} else if ( volume > maxVolumeB ) {
+
+							envMapB = probes[ i ].texture;
 							maxVolumeB = volume;
+
 						}
+
 					}
+
 				}
 
 				const blend = envMapB ?
-					maxVolumeB / (maxVolumeA + maxVolumeB) : 
-					1 - (maxVolumeA / _tmpObjectAABB.volume())
+					  maxVolumeB / ( maxVolumeA + maxVolumeB ) :
+					  1 - ( maxVolumeA / _tmpObjectAABB.volume() );
 
 				envMapA = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapA || environment );
 				envMapB = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( envMapB || environment );
@@ -1796,19 +1809,24 @@ function WebGLRenderer( parameters = {} ) {
 				p_uniforms.setValue( _gl, 'envMap2', envMapB, textures );
 				p_uniforms.setValue( _gl, 'envMapBlend', blend );
 
-				if(object.reflectionProbeMode === "static") {
+				if(object.reflectionProbeMode === 'static') {
+
 					object.__webglStaticReflectionProbe = {
 						envMap: envMapA,
 						envMap2: envMapB,
 						envMapBlend: blend
 					}
+
 				}
+
 			} else {
+
 				// p_uniforms.setValue( _gl, 'envMap', envMapA, textures );
 				p_uniforms.setValue( _gl, 'envMap2', cubeuvmaps.get(scene.environment), textures);
 				p_uniforms.setValue( _gl, 'envMapBlend', 0 );
-                
+
 			}
+
 		}
 
 		if ( !! geometry && ( geometry.morphAttributes.position !== undefined || geometry.morphAttributes.normal !== undefined ) ) {
@@ -1855,10 +1873,12 @@ function WebGLRenderer( parameters = {} ) {
 
 			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget );
 
-            // TODO HACK refreshMaterialUniforms overrides this, we need to not be fighting it
-            if(envMapA) {
+			// TODO HACK refreshMaterialUniforms overrides this, we should not be fighting it, but we don't want to force a full refreshMateerialUniforms on every object every frame to support reflection probes
+			if ( envMapA ) {
+
 				m_uniforms.envMap.value = envMapA;
-            }
+
+			}
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1750,6 +1750,7 @@ function WebGLRenderer( parameters = {} ) {
 		}
 
         // Similar to note about skinned meshes above, this must be done before other texture uploads otherwise the texture units might overlap
+		let envMapA = null;
 		if(materialProperties.envMap && material.isMeshStandardMaterial) {
 			if(object.reflectionProbeMode === "static" && object.__webglStaticReflectionProbe) {
 				p_uniforms.setValue( _gl, 'envMap', object.__webglStaticReflectionProbe.envMap, textures );
@@ -1763,7 +1764,6 @@ function WebGLRenderer( parameters = {} ) {
 
 				_tmpObjectAABB.copy(geometry.boundingBox).applyMatrix4(object.matrixWorld);
 
-				let envMapA = null;
 				let envMapB = null;
 				let maxVolumeA = 0;
 				let maxVolumeB = 0;
@@ -1854,6 +1854,11 @@ function WebGLRenderer( parameters = {} ) {
 			}
 
 			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget );
+
+            // TODO HACK refreshMaterialUniforms overrides this, we need to not be fighting it
+            if(envMapA) {
+				m_uniforms.envMap.value = envMapA;
+            }
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 

--- a/src/renderers/shaders/ShaderChunk/envmap_common_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_common_pars_fragment.glsl.js
@@ -5,10 +5,13 @@ export default /* glsl */`
 	uniform float flipEnvMap;
 	uniform int maxMipLevel;
 
+	uniform float envMapBlend;
+
 	#ifdef ENVMAP_TYPE_CUBE
 		uniform samplerCube envMap;
 	#else
 		uniform sampler2D envMap;
+		uniform sampler2D envMap2;
 	#endif
 	
 #endif

--- a/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
@@ -14,6 +14,9 @@ export default /* glsl */`
 			vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );
 
 			vec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );
+			vec4 envMap2Color = textureCubeUV( envMap2, worldNormal, 1.0 );
+
+			envMapColor = mix(envMapColor, envMap2Color, envMapBlend);
 
 			return PI * envMapColor.rgb * envMapIntensity;
 
@@ -47,6 +50,9 @@ export default /* glsl */`
 			reflectVec = inverseTransformDirection( reflectVec, viewMatrix );
 
 			vec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );
+			vec4 envMap2Color = textureCubeUV( envMap2, reflectVec, roughness );
+
+			envMapColor = mix(envMapColor, envMap2Color, envMapBlend);
 
 			return envMapColor.rgb * envMapIntensity;
 

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -75,7 +75,13 @@ const ShaderLib = {
 
 		uniforms: mergeUniforms( [
 			UniformsLib.common,
-			UniformsLib.envmap,
+			( () => {
+
+				// TODO HACK don't include envMap uniform, it is currently handling directly in WebGLRenderer for ReflectionProbes support
+				const { envMap, ...rest } = UniformsLib.envmap; // eslint-disable-line no-unused-vars
+				return rest;
+
+			} )(),
 			UniformsLib.aomap,
 			UniformsLib.lightmap,
 			UniformsLib.emissivemap,

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -31,6 +31,8 @@ const UniformsLib = {
 	envmap: {
 
 		envMap: { value: null },
+		envMap2: { value: null },
+		envMapBlend: { value: 0 },
 		flipEnvMap: { value: - 1 },
 		reflectivity: { value: 1.0 }, // basic, lambert, phong
 		ior: { value: 1.5 }, // standard, physical

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -31,8 +31,6 @@ const UniformsLib = {
 	envmap: {
 
 		envMap: { value: null },
-		envMap2: { value: null },
-		envMapBlend: { value: 0 },
 		flipEnvMap: { value: - 1 },
 		reflectivity: { value: 1.0 }, // basic, lambert, phong
 		ior: { value: 1.5 }, // standard, physical

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -249,7 +249,7 @@ function WebGLLights( extensions, capabilities ) {
 
 			} else if ( light.isReflectionProbe ) {
 
-				state.reflectionProbes[numReflectionProbes++] = light
+				state.reflectionProbes[ numReflectionProbes ++ ] = light;
 
 			} else if ( light.isDirectionalLight ) {
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -174,6 +174,7 @@ function WebGLLights( extensions, capabilities ) {
 
 		ambient: [ 0, 0, 0 ],
 		probe: [],
+		reflectionProbes: [],
 		directional: [],
 		directionalShadow: [],
 		directionalShadowMap: [],
@@ -215,6 +216,8 @@ function WebGLLights( extensions, capabilities ) {
 		let numPointShadows = 0;
 		let numSpotShadows = 0;
 
+		let numReflectionProbes = 0;
+
 		lights.sort( shadowCastingLightsFirst );
 
 		// artist-friendly light intensity scaling factor
@@ -243,6 +246,10 @@ function WebGLLights( extensions, capabilities ) {
 					state.probe[ j ].addScaledVector( light.sh.coefficients[ j ], intensity );
 
 				}
+
+			} else if ( light.isReflectionProbe ) {
+
+				state.reflectionProbes[numReflectionProbes++] = light
 
 			} else if ( light.isDirectionalLight ) {
 
@@ -410,6 +417,8 @@ function WebGLLights( extensions, capabilities ) {
 		state.ambient[ 0 ] = r;
 		state.ambient[ 1 ] = g;
 		state.ambient[ 2 ] = b;
+
+		state.reflectionProbes.length = numReflectionProbes;
 
 		const hash = state.hash;
 

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -149,7 +149,12 @@ function WebGLMaterials( properties ) {
 
 		if ( envMap ) {
 
-			uniforms.envMap.value = envMap;
+			// TODO HACK currently handling directly in WebGLRenderer only for MeshStandardMaterial for ReflectionProbes
+			if ( ! material.isMeshStandardMaterial ) {
+
+				uniforms.envMap.value = envMap;
+
+			}
 
 			uniforms.flipEnvMap.value = ( envMap.isCubeTexture && envMap.isRenderTargetTexture === false ) ? - 1 : 1;
 


### PR DESCRIPTION
Adds a new primitive called **ReflectionProbe**. A **ReflectionProbe** has a `box` which defines the axis aligned bounding box in which it applies, and a `texture` which defines the equirectangular texture that will be used as the environment map for objects inside this box. If an object is overlapping multiple **ReflectionProbe** boxes its environment map will be a mix of the 2 most overlapped boxes, with the mixing being proportional to the amount of overlap. Object overlap is computed by the object's axis aligned bounding box.

By default objects will not be effected by reflection probes. An object must set the property `reflectionProbeType` to either `static` or `dynamic`. When `static` the object will only check itself against **ReflectionProbes** the first time it is rendered. When `dynamic` this check will happen every frame. The checks should be fairly lightweight, but for static geometry like scenes it is a nice optimization. 

The "correct' way to do this would probably be to update these environment uniforms in the same place as other uniforms on **MeshStandardMaterial**, but that would require invalidating the material every frame, which would lead to a whole bunch of unnecessary uniform updates for every object every frame. Additionally, its pretty common for multiple objects to reuse the same material. Currently there would be no way to use different environment maps on those objects without either duplicating the material or invalidating the material in a `beforeRender` call for each object (meaning for a given material we would be uploading all of its uniforms multiple times per frame unnecessarily. The way I have done it is slightly hacky but I think it could be cleaned up a bit if we want to try and land it upstream.

Before merging this I plan to flatten the commit and drop the built assets to match the other patch commits we have in the `hubs-patches-133` branch. I am including the built assets for now to make it easier to test a hubs client against.