### PR TITLE
Fix reflection probes for flat objects and skip doing work at all when no reflection probes are defined.

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -9,12 +9,6 @@ class Box3 {
 
 	}
 
-	volume() {
-
-		return ( ( this.max.x - this.min.x ) * ( this.max.y - this.min.y ) * ( this.max.z - this.min.z ) );
-
-	}
-
 	set( min, max ) {
 
 		this.min.copy( min );


### PR DESCRIPTION
The bounding box for flat planes have a 0 volume since they are infinitely thin, this would result in `NaN` for `envMapBlend` which would result in these objects rendering black. This also revealed that the ReflectionProbe codepath was being hit even when no probes were in the scene. This PR fixes both issues.