### PR TITLE
Dirty flag optimization

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -12,6 +12,7 @@ let _object3DId = 0;
 const _v1 = /*@__PURE__*/ new Vector3();
 const _q1 = /*@__PURE__*/ new Quaternion();
 const _m1 = /*@__PURE__*/ new Matrix4();
+const _m2 = /*@__PURE__*/ new Matrix4();
 const _target = /*@__PURE__*/ new Vector3();
 
 const _position = /*@__PURE__*/ new Vector3();
@@ -30,6 +31,8 @@ const _zeroQuat = new Quaternion();
 const _oneScale = new Vector3( 1, 1, 1 );
 const _identity = new Matrix4();
 _identity.identity();
+
+const _epsilon = 0.00000000001;
 
 class Object3D extends EventDispatcher {
 
@@ -666,6 +669,8 @@ class Object3D extends EventDispatcher {
 
 		if ( this.matrixWorldNeedsUpdate || forceWorldUpdate ) {
 
+			_m2.copy( this.matrixWorld );
+
 			if ( this.parent === null ) {
 
 				this.matrixWorld.copy( this.matrix );
@@ -692,7 +697,16 @@ class Object3D extends EventDispatcher {
 
 			}
 
-			this.childrenNeedMatrixWorldUpdate = true;
+			if ( _m2.near( this.matrixWorld, _epsilon ) ) {
+
+				this.matrixWorld.copy( _m2 );
+
+			} else {
+
+				this.childrenNeedMatrixWorldUpdate = true;
+
+			}
+
 			this.matrixWorldNeedsUpdate = false;
 
 		}

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -11,6 +11,7 @@ let _object3DId = 0;
 
 const _v1 = /*@__PURE__*/ new Vector3();
 const _q1 = /*@__PURE__*/ new Quaternion();
+const _q2 = /*@__PURE__*/ new Quaternion();
 const _m1 = /*@__PURE__*/ new Matrix4();
 const _m2 = /*@__PURE__*/ new Matrix4();
 const _target = /*@__PURE__*/ new Vector3();
@@ -295,6 +296,8 @@ class Object3D extends EventDispatcher {
 
 		}
 
+		_q2.copy( this.quaternion );
+
 		this.quaternion.setFromRotationMatrix( _m1 );
 
 		if ( parent ) {
@@ -305,7 +308,15 @@ class Object3D extends EventDispatcher {
 
 		}
 
-		this.matrixNeedsUpdate = true;
+		if ( _q2.near( this.quaternion, _epsilon ) ) {
+
+			this.quaternion.copy( _q2 );
+
+		} else {
+
+			this.matrixNeedsUpdate = true;
+
+		}
 
 	}
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -830,6 +830,22 @@ class Matrix4 {
 
 	}
 
+	// [HUBS] Similar to equals() but allow the diff under eps.
+	near( matrix, eps = Number.EPSILON ) {
+
+		const te = this.elements;
+		const me = matrix.elements;
+
+		for ( let i = 0; i < 16; i ++ ) {
+
+			if ( Math.abs( te[ i ] - me[ i ] ) >= eps ) return false;
+
+		}
+
+		return true;
+
+	}
+
 	fromArray( array, offset = 0 ) {
 
 		for ( let i = 0; i < 16; i ++ ) {

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -637,6 +637,16 @@ class Quaternion {
 
 	}
 
+	// [HUBS] Similar to equals() but allows the diff under eps
+	near( quaternion, eps = Number.EPSILON ) {
+
+		return ( Math.abs( quaternion._x - this._x ) < eps ) &&
+			( Math.abs( quaternion._y - this._y ) < eps ) &&
+			( Math.abs( quaternion._z - this._z ) < eps ) &&
+			( Math.abs( quaternion._w - this._w ) < eps );
+
+	}
+
 	fromArray( array, offset = 0 ) {
 
 		this._x = array[ offset ];

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -665,6 +665,15 @@ class Vector3 {
 
 	}
 
+	// [HUBS] Similar to equals() but allows the diff under eps
+	near( v, eps = Number.EPSILON ) {
+
+		return ( Math.abs( v.x - this.x ) < eps ) &&
+			( Math.abs( v.y - this.y ) < eps ) &&
+			( Math.abs( v.z - this.z ) < eps );
+
+	}
+
 	fromArray( array, offset = 0 ) {
 
 		this.x = array[ offset ];


### PR DESCRIPTION
Related: https://github.com/mozilla/hubs/issues/5322

This PR is for dirty flag optimization.

Setting the dirty flag, especially of near root objects, `true` can have a big bad performance impact. Because it can cause all the child world matrices update. So we need to be careful when raising the flags.

I would like to suggest to raise the flags only if the new values have diff from the current ones.

Checking the diff can be performance panalty for moving objects but generally not all the objects in a scene move at a certain frame. Probably the benefit wins to the penalty in most cases.

**Additinonal context**

In this PR I suggest to raise `childrenNeedMatrixWorldUpdate` flag if the new world matrix values have diff from the current values in `updateMatrices()` like.

```
if ( _m1.near( this.matrixWorld, _epsilon ) ) {
    this.matrixWorld.copy( _m1 );
} else {
    this.childrenNeedMatrixWorldUpdate = true;
}
```

Ideally we should do this check when updating position/quaternion/scale/local matrix/world matrix and raising the dirty flag in the Hubs components/systems instead. If we do that we can remove this costly check in `updateMatrices()` which runs for every world matrix update.

But there are many components and systems updating them, it may take time to optimize them. So I would like to suggest to do the check for world matrix update in `updateMatrices()` as short-term solution. And later we can optimize the Hubs components and systems, and remove the check in `updateMatrices()`.