### PR TITLE
Fix a problem that an invisible object loses an oppotunity to update the matrices

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -593,7 +593,22 @@ class Object3D extends EventDispatcher {
 	// includeInvisible - If true, does not ignore non-visible objects.
 	updateMatrixWorld( forceWorldUpdate, includeInvisible ) {
 
-		if ( ! this.visible && ! includeInvisible ) return;
+		if ( ! this.visible && ! includeInvisible ) {
+
+			if ( this.parent && this.parent.childrenNeedMatrixWorldUpdate ) {
+
+				// The parent's childrenNeedMatrixWorldUpdate is cleared
+				// if this method is recursively called from the parent
+				// and this object may lose the opportunity to update
+				// the world matrix. So raise the matrixWorldNeedsUpdate flag
+				// instead, and update it later when needed.
+				this.matrixWorldNeedsUpdate = true;
+
+			}
+
+			return;
+
+		}
 
 		// Do not recurse upwards, since this is recursing downwards
 		this.updateMatrices( false, forceWorldUpdate, true );

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -850,6 +850,110 @@ export default QUnit.module( 'Core', () => {
 				4, 5, 6, 1
 			], "updateMatrixWorld() calculates world matrix from the current parent world matrix" );
 
+			// [HUBS] Hubs special flag matrixNeedsUpdate test
+
+			parent.matrix.identity();
+			parent.matrixWorld.identity();
+			parent.matrixAutoUpdate = false;
+			parent.matrixNeedsUpdate = false;
+			parent.visible = true;
+			child.matrix.identity();
+			child.matrixWorld.identity();
+			child.matrixAutoUpdate = false;
+			child.matrixNeedsUpdate = false;
+			child.visible = true;
+
+			parent.position.set( 1, 2, 3 );
+			parent.updateMatrixWorld();
+
+			assert.deepEqual( parent.matrix.elements, [
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1
+			], "[HUBS] No effect to local matrix if matrixNeedsUpdate is false" );
+
+			assert.deepEqual( parent.matrixWorld.elements, [
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1
+			], "[HUBS] No effect to world matrix if matrixNeedsUpdate is false" );
+
+			parent.matrixNeedsUpdate = true;
+			parent.updateMatrixWorld();
+
+			assert.deepEqual( parent.matrix.elements, [
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				1, 2, 3, 1
+			], "[HUBS] Have an effect to local matrix if matrixNeedsUpdate is true" );
+
+			assert.deepEqual( parent.matrixWorld.elements, [
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				1, 2, 3, 1
+			], "[HUBS] Have an effect to world matrix if matrixNeedsUpdate is true" );
+
+			assert.deepEqual( child.matrixWorld.elements, [
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				1, 2, 3, 1
+			], "[HUBS] Have an effect to child world matrix if parent's matrixNeedsUpdate is true" );
+
+			assert.ok( parent.matrixNeedsUpdate === false, "[HUBS] matrixNeedsUpdate is cleared after the matrices update" );
+
+			// [HUBS] visibility test
+
+			parent.matrix.identity();
+			parent.matrixWorld.identity();
+			parent.visible = false;
+			child.matrix.identity();
+			child.matrixWorld.identity();
+			child.matrixNeedsUpdate = false;
+			child.visible = false;
+
+			parent.position.set( 1, 2, 3 );
+			parent.matrixNeedsUpdate = true;
+			parent.updateMatrixWorld();
+
+			assert.deepEqual( parent.matrix.elements, [
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1
+			], "[HUBS] No effect to matrix of an invisible object" );
+
+			parent.visible = true;
+			parent.updateMatrixWorld();
+
+			assert.deepEqual( parent.matrix.elements, [
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				1, 2, 3, 1
+			], "[HUBS] Have an effect to matrix of a visible object" );
+
+			assert.deepEqual( child.matrixWorld.elements, [
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, 1
+			], "[HUBS] No propagate to invisible child object's world matrix" );
+
+			child.visible = true;
+			parent.updateMatrixWorld();
+
+			assert.deepEqual( child.matrixWorld.elements, [
+				1, 0, 0, 0,
+				0, 1, 0, 0,
+				0, 0, 1, 0,
+				1, 2, 3, 1
+			], "[HUBS] Propagate to child object's world matrix later when it becomes visible" );
+
 		} );
 
 		QUnit.test( "updateWorldMatrix", ( assert ) => {


### PR DESCRIPTION
`Object3D.updateMatrixWorld()` skips the update of invisible objects unless `includeInvisible` parameter is true.

Regardless of an object's visibility, its parent's `childrenNeedMatrixWorldUpdate` is cleared if `Object3D.updateMatrixWorld()` is recursively called from the parent.

In that case the parent's `childNeedMatrixWorldUpdate` is cleared and the object's `matrixNeedsUpdate` or `matrixWorldNeedsUpdate` isn't set (unless manually it's set) so that the object may lose the opportunity to update the world matrix. As a result the object can be rendered at a wrong place in the scene when it becomes visible.

This PR resolves the problem by raising the `matrixWorldNeedsUpdate` flag instead in that case, and the object's world matrix can be updated later when needed.